### PR TITLE
(In Progress) Input Params

### DIFF
--- a/rail_wrap_test.ipynb
+++ b/rail_wrap_test.ipynb
@@ -2,77 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "1c2a2dbf",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Training script for LazyConfig models\n",
-    "try:\n",
-    "    # ignore ShapelyDeprecationWarning from fvcore\n",
-    "    import warnings\n",
-    "\n",
-    "    from shapely.errors import ShapelyDeprecationWarning\n",
-    "\n",
-    "    warnings.filterwarnings(\"ignore\", category=ShapelyDeprecationWarning)\n",
-    "\n",
-    "except:\n",
-    "    pass\n",
-    "warnings.filterwarnings(\"ignore\", category=RuntimeWarning)\n",
-    "warnings.filterwarnings(\"ignore\", category=UserWarning)\n",
-    "\n",
-    "# Some basic setup:\n",
-    "# Setup detectron2 logger\n",
-    "from detectron2.utils.logger import setup_logger\n",
-    "\n",
-    "setup_logger()\n",
-    "\n",
-    "import gc\n",
-    "import os\n",
-    "import time\n",
-    "\n",
-    "import detectron2.utils.comm as comm\n",
-    "\n",
-    "# import some common libraries\n",
-    "import numpy as np\n",
-    "import torch\n",
-    "\n",
-    "# import some common detectron2 utilities\n",
-    "from detectron2.config import LazyConfig, get_cfg\n",
-    "import detectron2.data as data\n",
-    "from detectron2.engine import (\n",
-    "    launch,\n",
-    ")\n",
-    "\n",
-    "from deepdisc.data_format.augment_image import train_augs\n",
-    "from deepdisc.data_format.image_readers import DC2ImageReader\n",
-    "from deepdisc.data_format.register_data import (\n",
-    "    register_data_set,\n",
-    ")  # , register_loaded_data_set\n",
-    "from deepdisc.model.loaders import (\n",
-    "    RedshiftFlatDictMapper,\n",
-    "    return_test_loader,\n",
-    "    return_train_loader,\n",
-    ")\n",
-    "from deepdisc.model.models import (\n",
-    "    RedshiftPointCasROIHeads,\n",
-    "    RedshiftPointROIHeads,\n",
-    "    RedshiftPDFROIHeads,\n",
-    "    return_lazy_model,\n",
-    ")\n",
-    "from deepdisc.training.trainers import (\n",
-    "    return_evallosshook,\n",
-    "    return_lazy_trainer,\n",
-    "    return_optimizer,\n",
-    "    return_savehook,\n",
-    "    return_schedulerhook,\n",
-    ")\n",
-    "from deepdisc.utils.parse_arguments import make_training_arg_parser"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "6167f21e-0bbc-45cb-bc06-aac14f765fa4",
    "metadata": {},
    "outputs": [],
@@ -83,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "5244b7ff-1501-47ad-b74e-c575f9758089",
    "metadata": {},
    "outputs": [],
@@ -99,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "4e82e6de-f6ec-46b5-a6a7-60e79cd79c31",
    "metadata": {},
    "outputs": [],
@@ -122,21 +52,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "4ed14575-d55b-4400-90f9-752f27cc75c6",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'detectron2://ImageNetPretrained/MSRA/R-50.pkl'"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "cfg = get_lazy_config(cfgfile, 1, 1)\n",
     "cfg.train.init_checkpoint"
@@ -144,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "ffd06982-1e98-4b8a-a3a8-b68ac71cd6bc",
    "metadata": {},
    "outputs": [],
@@ -163,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "9940c5c2-b692-4e3b-a595-0afec0c21e93",
    "metadata": {},
    "outputs": [],
@@ -178,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "01f48f9e-16a3-423d-a550-ed9298b6fafb",
    "metadata": {},
    "outputs": [],
@@ -195,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "a57e206a-c5c6-4526-a278-868ef2a6047b",
    "metadata": {},
    "outputs": [],
@@ -215,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "d611ae20-a7c7-4f52-9390-1d27eca138f0",
    "metadata": {},
    "outputs": [],
@@ -228,92 +147,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "87b6a9d1-697e-4bde-abee-e519253daa6f",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "caching data\n",
-      "\u001b[32m[12/07 14:11:26 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
-      "\u001b[32m[12/07 14:11:26 d2.data.common]: \u001b[0mSerializing 1000 elements to byte tensors and concatenating them all ...\n",
-      "\u001b[32m[12/07 14:11:29 d2.data.common]: \u001b[0mSerialized dataset takes 274.77 MiB\n",
-      "\u001b[32m[12/07 14:11:29 d2.data.build]: \u001b[0mMaking batched data loader with batch_size=1\n",
-      "\u001b[32m[12/07 14:11:29 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
-      "\u001b[32m[12/07 14:11:29 d2.data.common]: \u001b[0mSerializing 1000 elements to byte tensors and concatenating them all ...\n",
-      "\u001b[32m[12/07 14:11:32 d2.data.common]: \u001b[0mSerialized dataset takes 274.77 MiB\n",
-      "\u001b[32m[12/07 14:11:32 d2.checkpoint.detection_checkpoint]: \u001b[0m[DetectionCheckpointer] Loading from detectron2://ImageNetPretrained/MSRA/R-50.pkl ...\n",
-      "\u001b[32m[12/07 14:11:32 d2.checkpoint.c2_model_loading]: \u001b[0mRenaming Caffe2 weights ......\n",
-      "\u001b[5m\u001b[31mWARNING\u001b[0m \u001b[32m[12/07 14:11:32 d2.checkpoint.c2_model_loading]: \u001b[0mShape of stem.conv1.weight in checkpoint is torch.Size([64, 3, 7, 7]), while shape of backbone.bottom_up.stem.conv1.weight in model is torch.Size([64, 6, 7, 7]).\n",
-      "\u001b[5m\u001b[31mWARNING\u001b[0m \u001b[32m[12/07 14:11:32 d2.checkpoint.c2_model_loading]: \u001b[0mstem.conv1.weight will not be loaded. Please double check and see if this is desired.\n",
-      "\u001b[32m[12/07 14:11:32 d2.checkpoint.c2_model_loading]: \u001b[0mFollowing weights matched with submodule backbone.bottom_up - Total num: 53\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Some model parameters or buffers are not found in the checkpoint:\n",
-      "\u001b[34mbackbone.bottom_up.stem.conv1.weight\u001b[0m\n",
-      "\u001b[34mbackbone.fpn_lateral2.{bias, weight}\u001b[0m\n",
-      "\u001b[34mbackbone.fpn_lateral3.{bias, weight}\u001b[0m\n",
-      "\u001b[34mbackbone.fpn_lateral4.{bias, weight}\u001b[0m\n",
-      "\u001b[34mbackbone.fpn_lateral5.{bias, weight}\u001b[0m\n",
-      "\u001b[34mbackbone.fpn_output2.{bias, weight}\u001b[0m\n",
-      "\u001b[34mbackbone.fpn_output3.{bias, weight}\u001b[0m\n",
-      "\u001b[34mbackbone.fpn_output4.{bias, weight}\u001b[0m\n",
-      "\u001b[34mbackbone.fpn_output5.{bias, weight}\u001b[0m\n",
-      "\u001b[34mproposal_generator.rpn_head.anchor_deltas.{bias, weight}\u001b[0m\n",
-      "\u001b[34mproposal_generator.rpn_head.conv.{bias, weight}\u001b[0m\n",
-      "\u001b[34mproposal_generator.rpn_head.objectness_logits.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.box_head.fc1.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.box_head.fc2.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.box_predictor.bbox_pred.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.box_predictor.cls_score.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.mask_head.deconv.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.mask_head.mask_fcn1.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.mask_head.mask_fcn2.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.mask_head.mask_fcn3.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.mask_head.mask_fcn4.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.mask_head.predictor.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.redshift_fc.0.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.redshift_fc.2.{bias, weight}\u001b[0m\n",
-      "The checkpoint state_dict contains keys that are not used by the model:\n",
-      "  \u001b[35mfc1000.{bias, weight}\u001b[0m\n",
-      "  \u001b[35mstem.conv1.{bias, weight}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Model training:\n",
-      "\u001b[32m[12/07 14:11:32 d2.engine.train_loop]: \u001b[0mStarting training from iteration 0\n",
-      "<detectron2.solver.lr_scheduler.LRMultiplier object at 0x7ffd9435f7c0>\n",
-      "Iteration:  5  time:  3.7695281207561493e-07 dict_keys(['loss_cls', 'loss_box_reg', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5891743302345276, 0.2904547452926636, 0.12975382804870605, 0.6079576015472412, 0.20023879408836365] val loss:  0 lr:  [0.001]\n",
-      "Iteration:  10  time:  4.2212195694446564e-07 dict_keys(['loss_cls', 'loss_box_reg', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5516690015792847, 0.25014349818229675, 0.12637390196323395, 0.47483837604522705, 0.19491952657699585] val loss:  0 lr:  [0.001]\n",
-      "Iteration:  15  time:  3.6903657019138336e-07 dict_keys(['loss_cls', 'loss_box_reg', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.48746970295906067, 0.2049514651298523, 0.10832422971725464, 0.3043662905693054, 0.18178178369998932] val loss:  0 lr:  [0.001]\n",
-      "Iteration:  20  time:  3.6996789276599884e-07 dict_keys(['loss_cls', 'loss_box_reg', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.4865964651107788, 0.25734609365463257, 0.12529031932353973, 0.2194424867630005, 0.22261971235275269] val loss:  0 lr:  [0.001]\n",
-      "saving test_informer\n",
-      "Inserting handle into data store.  model_Inform_DeepDISC: inprogress_test_informer.pkl, Inform_DeepDISC\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<rail.core.data.ModelHandle at 0x7ffd94490b50>"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "Inform.inform(training, metadatahandle)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33219663-1e23-4470-a4f5-c70c996bd9ab",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -327,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "7070dcb2-0de8-42af-af8d-f40c689b7cb1",
    "metadata": {},
    "outputs": [],
@@ -337,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "7360caf2-5b3d-4998-be0c-3ca28fb5e035",
    "metadata": {},
    "outputs": [],
@@ -355,44 +203,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
+   "id": "ee7b2bd2-4a8c-4b2f-bb25-336c32fd367d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "help(Estimator)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "c74bb222-f53c-415c-acab-f8b978a2af5d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "caching data\n",
-      "\u001b[32m[12/07 14:12:36 d2.checkpoint.detection_checkpoint]: \u001b[0m[DetectionCheckpointer] Loading from ./test_informer.pth ...\n",
-      "Processing Data\n",
-      "Matching objects\n",
-      "Inserting handle into data store.  output_DeepDiscEstimator: inprogress_output_DeepDiscEstimator.hdf5, DeepDiscEstimator\n",
-      "Inserting handle into data store.  truth_DeepDiscEstimator: inprogress_truth_DeepDiscEstimator, DeepDiscEstimator\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "results = Estimator.estimate(testing, metadatahandle)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "5b402ba2-3779-44e7-8654-113f19731464",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<qp.ensemble.Ensemble at 0x7ffd91b1e820>"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "res = results.read()\n",
     "res"
@@ -400,7 +234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "41d2b4a5-0422-4f8f-8e08-49811549c46a",
    "metadata": {},
    "outputs": [],
@@ -410,7 +244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "id": "94da4c4a-93c6-4203-a1b3-4fe186bad242",
    "metadata": {},
    "outputs": [],
@@ -420,7 +254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "b958d33f-c330-4149-aa97-fe1970555bc6",
    "metadata": {},
    "outputs": [],
@@ -430,7 +264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "18e185eb-397a-41b8-978e-871a9f624cab",
    "metadata": {},
    "outputs": [],
@@ -449,7 +283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "f7417fa3-0c51-4a04-837c-f9e54431eeda",
    "metadata": {},
    "outputs": [],
@@ -459,59 +293,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "e7ba5ca0-7ded-4b4c-ac63-264c8c23ec98",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Inserting handle into data store.  output_DeepDiscEvaluator: inprogress_output_DeepDiscEvaluator.hdf5, DeepDiscEvaluator\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "eval_res = DeepEvaluator.evaluate(res,truth)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "6cf80908-9582-45ca-b78f-f5163fb415a7",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'PIT_AD_stat': array([0.89898409]),\n",
-       " 'PIT_AD_pval': array([nan]),\n",
-       " 'PIT_AD_significance_level': array([0.13953459]),\n",
-       " 'PIT_CvM_stat': array([0.31212486]),\n",
-       " 'PIT_CvM_pval': array([nan]),\n",
-       " 'PIT_CvM_significance_level': array([nan]),\n",
-       " 'PIT_KS_stat': array([0.12407934]),\n",
-       " 'PIT_KS_pval': array([nan]),\n",
-       " 'PIT_KS_significance_level': array([nan]),\n",
-       " 'PIT_OutRate_stat': array([nan]),\n",
-       " 'PIT_OutRate_pval': array([nan]),\n",
-       " 'PIT_OutRate_significance_level': array([nan]),\n",
-       " 'CDE_stat': array([-0.39978568]),\n",
-       " 'CDE_pval': array([nan])}"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "eval_res.data"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "id": "f874ba48-786b-46d9-845d-d659c86cdc78",
    "metadata": {},
    "outputs": [],
@@ -524,7 +326,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "id": "e6de28b4-61c2-4d6f-ab20-46a0d369364f",
    "metadata": {},
    "outputs": [],
@@ -648,7 +450,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "id": "ee26258c-8401-45ed-a75d-92da6ed7f41b",
    "metadata": {},
    "outputs": [],
@@ -762,29 +564,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "id": "7a1263c0-1b38-4042-956c-902f1065c611",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_1488288/663945040.py:80: MatplotlibDeprecationWarning: The legendHandles attribute was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use legend_handles instead.\n",
-      "  for item in leg.legendHandles:\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAboAAAHmCAYAAAAFu0sJAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/SrBM8AAAACXBIWXMAAA9hAAAPYQGoP6dpAACWkElEQVR4nOzdd3QU1dvA8e+mhxBCD733FkoEEkB6r4qKgnRUBKTZQHxBsGD5iYjSCSAKgvReIjWA9IQWmvSSEAikEEhCkvv+MWTNpu4mm7Z5Pufs0b1z78ydzTLP3plbdEophRBCCGGhrLK7AkIIIURmkkAnhBDCokmgE0IIYdEk0AkhhLBoEuiEEEJYNAl0QgghLJoEOiGEEBZNAp0QQgiLJoFOCCGERZNAJ3K8pUuXotPp9C8bGxvKlCnD4MGDuXv3rj7fvn370Ol0rFmzBsCgTGqvffv2pXr8iIgIvv32Wxo0aED+/PnJnz8/DRo04LvvvuPZs2dmK5MR/v7+fPHFF9y4ccPs+86IL774Ap1Ol66yK1asYObMmeatkMiTbLK7AkIYa8mSJdSoUYNnz55x4MABpk+fzv79+zl79ixOTk5J8v/zzz8G77/88kv27t3Lnj17DNJr1aqV4jHv379Pu3btuHr1KqNHj+b7778HYM+ePUydOpVVq1axa9cuihYtmqEyGeXv78/UqVNp1aoVFSpUMNt+s9OKFSs4d+4cY8eOze6qiFxOAp3INerUqYO7uzsArVu3JjY2li+//JINGzbQr1+/JPmbNm1q8L5YsWJYWVklSU/NgAEDuHjxInv37qV58+b69Pbt29O1a1dat27N0KFD2bhxY4bKCCEyj9y6FLlWfMC6efNmpuz/xIkT7Nq1i6FDhxoErHjNmzdnyJAhbNq0idOnT6e7TEYtXbqU119/HdB+AMTfkl26dKk+z+LFi3Fzc8PBwYHChQvzyiuvcOHCBf3233//HZ1Ol6QVDDBt2jRsbW25d+9eqvXYunUr9evXx97enooVK/K///0v2XyzZ8/m5Zdfpnjx4jg5OVG3bl2+//57nj9/rs/TqlUrtm7dys2bNw1uM8ebOnUqTZo0oXDhwhQoUICGDRvi5eWFzFEvkiOBTuRa//77L6C11DKDt7c3AL169UoxT/y2Xbt2pbtMRnXt2pVvvvkG0ILIP//8wz///EPXrl0BmD59OkOHDqV27dqsW7eOn3/+mTNnzuDh4cGVK1cA6NOnDyVKlGD27NkG+46JiWH+/Pm88sorlCpVKsU67N69m549e+Ls7MzKlSv54Ycf+Ouvv1iyZEmSvFevXqVv3778/vvvbNmyhaFDh/LDDz/w3nvv6fPMmTOHZs2aUaJECf35JAzCN27c4L333uOvv/5i3bp1vPrqq3zwwQd8+eWX6f8gheVSQuRwS5YsUYA6cuSIev78uQoPD1dbtmxRxYoVU87OziowMFAppdTevXsVoFavXp3sfgYOHKicnJyMPu7w4cMVoC5evJhingsXLihAjRw5Mt1lzGH16tUKUHv37jVIf/z4sXJ0dFRdunQxSL9165ayt7dXffv21adNmTJF2dnZqfv37+vTVq1apQC1f//+VI/fpEkTVapUKfXs2TN9WlhYmCpcuLBK7TITGxurnj9/rpYtW6asra3Vo0eP9Nu6du2qypcvn+pxE+5j2rRpqkiRIiouLi7NMiJvkRadyDWaNm2Kra0tzs7OdOvWjRIlSrB9+3ZcXV3TvU+lFDExMQYvU8sDJvUsNKZMRusV759//uHZs2cMGjTIIL1s2bK0adOG3bt369Pef/99ABYuXKhP+/XXX6lbty4vv/xyiseIiIjg+PHjvPrqqzg4OOjTnZ2d6d69e5L8vr6+9OjRgyJFimBtbY2trS0DBgwgNjaWy5cvG3Vee/bsoV27dri4uOj3MXnyZIKDgwkKCjJqHyLvkEAnco1ly5Zx/PhxfH19uXfvHmfOnKFZs2YZ2udvv/2Gra2twSteuXLlALh+/XqK5eO785ctWzbdZUytlymCg4MBKFmyZJJtpUqV0m8HcHV1pU+fPsyfP5/Y2FjOnDmDj48Po0aNSvUYjx8/Ji4ujhIlSiTZljjt1q1btGjRgrt37/Lzzz/j4+PD8ePH9bdMjRl6cezYMTp06ABoQfnQoUMcP36cSZMmGb0PkbdIr0uRa9SsWVPf69JcunfvzvHjx5Pd1qFDBz777DM2bNhAp06dks2zYcMGANq0aZPuMqbWyxRFihQBICAgIMm2e/fuJRniMGbMGH7//Xc2btzIjh07KFiwYLI9WhMqVKgQOp2OwMDAJNsSp23YsIGIiAjWrVtH+fLl9el+fn7GnhIrV67E1taWLVu2GLQg4z9XIZLI3junQqQt/hnd8ePHU81n7md0SinVsWNHZWNjow4ePJhkm4+Pj7KxsVHNmjXLcJmM2rRpkwLUtm3bDNLjn9H16NHDIP327dvK3t5e9evXL8m+PD09VePGjVW+fPnU2LFjjTq+sc/oZs2apQAVEBCgT4uLi1ONGzdO8ozx1VdfVcWLF09yrPHjx6v8+fOr6OhofdrTp09VuXLlFKCuX79uVJ1F3iG3LoVIxW+//Ub16tXp0KEDEydO5O+//+bvv//ms88+o2PHjpQoUYJVq1ZluExG1alTB4AFCxZw8OBBTpw4QXBwMAULFuT//u//2LRpEwMGDGD79u388ccftG7dGgcHB6ZMmZJkX2PGjOHYsWM8e/aMESNGGHX8L7/8ksDAQNq3b8+GDRtYu3Ytbdu2TTKQv3379tjZ2fHWW2+xfft21q9fT8eOHXn8+HGSfdatW5egoCDmzp3LsWPHOHHiBKD1Mn3y5Al9+/bF29ublStX0qJFC+zt7U392ERekd2RVoi0ZGeLTimlnjx5or7++mvl5uam8uXLpwAFqJ49exr0EsxomYyaOXOmqlixorK2tlaAWrJkiX7bokWLVL169ZSdnZ1ycXFRPXv2VOfPn092P1FRUcre3l516tTJpONv2rRJf4xy5cqpb7/9Vk2ZMiVJr8vNmzcrNzc35eDgoEqXLq0+/vhjtX379iQtukePHqnXXntNFSxYUOl0OoP9LF68WFWvXl3Z29urSpUqqenTpysvLy9p0Ylk6ZSSEZZCmCIsLIyWLVty//59fHx8qFy5cqaUyS6bN2+mR48ebN26lS5dumR3dYTIMAl0QqRDYGAgnp6exMXF4ePjk2oPyoyUyUr+/v7cvHmTMWPG4OTkxKlTp9I9IbMQOYkEOiEEoE27dejQIRo2bMhvv/1GjRo1srtKQpiFBDohhBAWzWJ7XR44cIDu3btTqlQpdDqdUWNs9u/fT6NGjXBwcKBSpUrMmzcv8ysqhBAiU1lsoIuIiMDNzY1ff/3VqPzXr1+nS5cutGjRAl9fXz777DNGjx7N2rVrM7mmQgghMlOeuHWp0+lYv359qjPKf/rpp2zatMlg6ZLhw4dz+vTpZJcuEUIIkTvIFGAv/PPPP/r58+J17NgRLy8vnj9/nuxcg1FRUURFRenfx8TEcOHCBcqWLYuVlcU2loUQeUhcXBz379+nQYMG2NjkzpCRO2udCQIDA5PMgu/q6kpMTAwPHz5MdlLc6dOnM3Xq1KyqohBCZJtjx47x0ksvZXc10kUCXQKJxwypNJZTmThxIuPHj9e/v337NnXq1OHYsWPJBkYhhMjpHjx4wJAhQ5JMtJ2R5bCymwS6F0qUKJFkpvWgoCBsbGz0M8AnZm9vbzC/nouLC6AtiVKmTJnMq6wQQmSCs2fP0qtXL27dugWAk07HL0oxBHL145jcW3Mz8/DwwNvb2yBt165duLu7p3stMCGEyC22bduGp4eHPsiVAQ4qRfvsrZZZWGyge/LkCX5+fvrm9/Xr1/Hz89P/ESdOnMiAAQP0+YcPH87NmzcZP348Fy5cYPHixXh5efHRRx9lR/WFECJrKMWTZcsY3KsXTyIiAHAHjgH1s7NeZmSxge7EiRM0aNCABg0aADB+/HgaNGjA5MmTAW0hyvigB1CxYkW2bdvGvn37qF+/Pl9++SWzZs2id+/e2VJ/IYTIdM+fw/Dh5B84kNXPn2ML9Ab2A5bUyyBPjKPLKnfu3KFs2bLcvn071Wd0sbGxPH/+PAtrJoxla2uLtbV1dldDiMwXGgqvvw4JHtmcBBqQoAXUvDl3hg+n7Ntvp3ldy8mkM0oWUkoRGBhISEhIdldFpKJgwYKUKFFCZu4XFuu6nx8L27fn64cPSfgtbwTg4gK9e8OgQdCiBdy5kz2VNCMJdFkoPsgVL16cfPnyyYU0h1FK8fTpU4KCggBkiIiwSIcPH6ZXu3Y8ePYMO+CL+A0ODjB7NvTrBxlYrf2LL75IMr7Y1dU1Sa/2rCSBLovExsbqg1xKwxVE9nN0dAS0oSXFixeX25jCoqxYsYIhQ4boZ3RaBXwC5CteHDZtgiZNzHKc2rVr8/fff+vfZ/e/Iwl0WST+mVy+fPmyuSYiLfF/o+fPn2f7P1AhzEEpxdSpUw1aWm2ANUA+gM2boXFjsx3PxsaGEiVKmG1/GWWxvS5zKrldmfPJ30hYksjISPr162cQ5N4BdgCFAJydoVEjsx7zypUrlCpViooVK/Lmm29y7do1s+7fVBLohBDCQt2/f582bdrw559/AtqPuB9bt2Y+oJ8Go3FjMOLORXh4OGFhYfpXwgntE2rSpAnLli1j586dLFy4kMDAQDw9PQkODjbPSaWDBDohhFkMXXqcoUuPZ3c1xAtXrlyhSZMm+mXGnJyc2LBhA+NjYw16WtK0qVH7q1WrFi4uLvrX9OnTk83XuXNnevfuTd26dWnXrh1bt24F4LfffsvI6WSIBLocYtCgQeh0OnQ6Hba2tri6utK+fXsWL15MXFxcltcnvi46nQ4nJyeqVq3KoEGDOHnypEG+ffv2odPpDIZMzJ8/Hzc3N5ycnChYsCANGjTgu+++MygXFhbGpEmTqFGjBg4ODpQoUYJ27dqxbt06ZGinEBlXvHhxnJycAChdujQHDx6kR5cucDzRjxEPD6P25+/vT2hoqP41ceJEo8o5OTlRt25drly5YlL9zUkCXQ7SqVMnAgICuHHjBtu3b6d169aMGTOGbt26ERMTk+X1WbJkCQEBAZw/f57Zs2fz5MkT/W2JlHh5eTF+/HhGjx7N6dOnOXToEJ988glPnjzR5wkJCcHT05Nly5YxceJETp06xYEDB+jTpw+ffPIJoaGhWXF6Qlg0FxcXtmzZQufOnTl27Bj169eHM2fg2TPDjEb2tHR2dqZAgQL6l72RQxCioqK4cOFC9g7XUcJsbt++rQB1+/btJNuePXum/P391bNnz5ItO3DgQNWzZ88k6bt371aAWrhwoVJKqZCQEPXOO++oYsWKKWdnZ9W6dWvl5+dnUGbTpk2qYcOGyt7eXlWsWFF98cUX6vnz5/rtgJozZ47q1KmTcnBwUBUqVFB//fWXwT4AtX79+iT1GTBggHJ2dlaPHj1SSim1d+9eBajHjx8rpZTq2bOnGjRoUIqfkVJKvf/++8rJyUndvXs3ybbw8HCDumaHtP5WInlDlhxTQ5Ycy+5q5FnPnz9XwcHBqWeaPVsp+O9VtWqa+03tupacDz/8UO3bt09du3ZNHTlyRHXr1k05OzurGzduGFU+M0iLLodr06YNbm5u+lt6Xbt2JTAwkG3btnHy5EkaNmxI27ZtefToEQA7d+7k7bffZvTo0fj7+zN//nyWLl3K119/bbDf//u//6N3796cPn2at99+m7feeosLFy6kWZ9x48YRHh6eZKWHeCVKlODIkSPcvHkz2e1xcXGsXLmSfv36UapUqSTb8+fPn2tXMRYiu4SFhdG9e3c6duzI06dPU8545IjheyOfz5nizp07vPXWW1SvXp1XX30VOzs7jhw5Qvny5c1+LGNJoMsFatSowY0bN9i7dy9nz55l9erVuLu7U7VqVf73v/9RsGBB1qxZA8DXX3/NhAkTGDhwIJUqVaJ9+/Z8+eWXzJ8/32Cfr7/+OsOGDaNatWp8+eWXuLu788svvxhVF4AbN24ku33KlCkULFiQChUqUL16dQYNGsRff/2lf8748OFDHj9+rN+PECJjbty4gaenJzt27ODEiRMMGzYs5cwvOqboZUKgW7lyJffu3SM6Opq7d++ydu1aatWqZfbjmEJ+OucCSil0Oh0nT57kyZMnSWZWefbsGVevXgXg5MmTHD9+3KAFFxsbS2RkJE+fPtUPhvZI9ADaw8MjyYrCKdUFUh5rVrJkSf755x/OnTvH/v37OXz4MAMHDmTRokXs2LEjzfJCCOP9888/9OrVSz9tXaFChXj33XeTz/zwIfz7r2GakR1RcjsJdLnAhQsXqFixInFxcZQsWZJ9+/YlyVOwYEFAuzU4depUXn311SR5HBwcUj2OMcEn/vZmxYoVU81Xp04d6tSpw8iRIzl48CAtWrRg//79tGzZkkKFChl1m1QIkbKVK1cyaNAg/Xi2qlWrsnXrVqpWrZp8gaNHDd87OkLduplcy5xBbl3mcHv27OHs2bP07t2bhg0bEhgYiI2NDVWqVDF4FS1aFICGDRty6dKlJNurVKmCldV/f+4jie7VHzlyxKjbiTNnzqRAgQK0a9fO6HOIv20RERGBlZUVffr0Yfny5dy7dy9J3oiIiGzpYSpEbqFeTOf11ltv6YNcq1atOHLkSMpBLigI/vrLMO2llyCPPA/PG2eZS0RFRREYGEhsbCz3799nx44dTJ8+nW7dujFgwACsrKzw8PCgV69efPfdd1SvXp179+6xbds2evXqhbu7O5MnT6Zbt26ULVuW119/HSsrK86cOcPZs2f56quv9MeKf87XvHlzli9fzrFjx/Dy8jKoT0hICIGBgURFRXH58mXmz5/Phg0bWLZsmb4Fmdj7779PqVKlaNOmDWXKlCEgIICvvvqKYsWK6W+XfvPNN+zbt48mTZrw9ddf4+7ujq2tLT4+PkyfPp3jx4+nuH8h8rLIyEiGDh3KihUr9GlDhgxh7ty52NnZGWaOjoZVq2DOHK01l3h8ah65bQnI8AJzyujwAkABysbGRhUrVky1a9dOLV68WMXGxurzhYWFqQ8++ECVKlVK2draqrJly6p+/fqpW7du6fPs2LFDeXp6KkdHR1WgQAHVuHFjtWDBAv12QM2ePVu1b99e2dvbq/Lly6s///zToD7xdQGUg4ODqly5sho4cKA6efKkQb7EwwvWrFmjunTpokqWLKns7OxUqVKlVO/evdWZM2cMyoWEhKgJEyaoqlWrKjs7O+Xq6qratWun1q9fr+Li4oz7wDOJDC9IHxlekPlmzpyp/3ep0+nU999/n/TfS2SkUtOnK1WypOFQgsSvjRuNOqapwwtyIllh3IxSW2E8MjKS69evU7FixTSflWU2nU7H+vXr6dWrV7bWI6fKSX+r3CR++i+vQS9lc00sV2xsLD179mTv3r0sX7486b/hmBjo0AH27k19R/XqwcmTRt26TO26llvIrUshhMglrK2t+fPPP7l27Rpubm5JM3z3XcpBLn9+aNsWOneGAQPyzPM5kEAnhBA51rx583B3d8fd3V2f5uzsnHyQO30aEq3sDUDLljB2LHTpAomf4+UREujyILlbLUTOFhsby/jx45k1axYlS5bk2LFjqd82jI6GgQPhxQLPAFhZwc6dYEIPaUslwwuEECIHCQsLo0ePHsyaNQuAgIAA1q9fn3qhadO0Fl1Cn34qQe4FadEJIUQOcfPmTbp168a5c+cAsLGxYd68eQwdOjT5AjEx8Mkn8NNPhul168KUKZlc29xDAp0QQuQAR48epWfPnty/fx/QpvNau3YtrVu3Tr7A48fQpw8knmDdxgaWLgUjl9HJC+TWZQ6SePHVSpUq8dFHHxEREaHfHt+dOOHCqMm9Bg0alKV1nzNnjr47fqNGjfDx8TFLmazMI0R2+euvv2jVqpU+yFWpUoUjR46kHOSuXNHWkUtuFZHp06Fhw0ysbS6UzeP4LEpGBowrpQ0a79SpkwoICFC3bt1Sy5cvV46Ojmr48OH67fFr1gUEBOhfM2fOVAUKFDBICwkJyZRzTM7KlSuVra2tWrhwofL391djxoxRTk5O6ubNmxkqk5V5EpIB4+kjA8bTZ/r06QYTNLRs2VI9fPgw5QI+PkoVLpx0ALidnVKLF5u9fpYwYFwCnRmZI9AlXnx12LBhqkSJEiluV0qpJUuWKBcXl4xUPUMaN26sD8bxatSooSZMmJChMlmZJyEJdOkjgS59vLy89EFu8ODBKioqKuXMf/6pBbTEQc7VVanDhzOlfpYQ6OTWZQ7n6OjI84RdhrPY0qVLU13VIDo6mpMnT9KhQweD9A4dOnD48OF0l8nKPEJkpyFDhjBhwgS+/fZbvLy8ks5ZGW/HDujbVxtKkFCDBnDiRN6au9JE0hklBzt27BgrVqygbdu2WXbMa9eucf78ebp37w6Ai4sL1atXTzH/w4cPiY2NxdXV1SDd1dWVwMDAdJfJyjxCZKVHjx5RuHBhg7Tp06enXigoCAYNSjoxc9eusHKlNuuJSJG06HKYLVu2kD9/fhwcHPDw8ODll182auVvc9m+fTsXL17Uv3/llVcM3qckcatPvVgsNqNlsjKPEJnN29ubypUrs2rVKuMLKQWDB8OLjip6I0bAhg0S5IwggS6Had26NX5+fly6dInIyEjWrVtH8eLF072/s2fP4uHhQZ06dejduzfRL2571KtXj8ePHwNw6NAhBg4cyP79+/n8889ZuHAhDRo04NmzZ2nuv2jRolhbWydpHQUFBSVpRZlSJivzCJEV5s2bR+fOnQkJCWHgwIGcPHnSuIKzZ8O2bYZp3brBr7/mqfkqM0ICXQ7j5ORElSpVKF++PLa2thnaV2RkJG+99Ra//fYb586do2jRoqxcuZKYmBiePHlCoUKFADhz5gy1a9emZcuW1KlTh927d+Pr64ujo2Oax7Czs6NRo0Z4J+rm7O3tjaenZ7rLZGUeITJTbGws48aN4/333yc2NhaAjh07pvpIAKXg8GGtJTd+vOE2V1fw8gK5I2E0+TlgwTZs2ECnTp2oVq0aADVq1ODBgwdcunRJnwZaoOvWrRvw35Ic8davX8/EiRNTvX05fvx4+vfvj7u7Ox4eHixYsIBbt24xfPhwfZ5ff/2V9evXs3v3bqPLZGUeITJDeHg4ffv2ZcuWLfq0Dz/8kO+++w5ra+vkC127pnU6OXo0+e2//QYZuMuTF0mgs2AXLlygZs2a+vfnz5+nd+/enDt3jjp16ujTT5w4wYQJE7hz5w6lS5c22EdoaCiXLl1K9Th9+vQhODiYadOmERAQQJ06ddi2bRvly5fX53n48CFXr141qUxW5hHC3G7fvk23bt04c+YMoE3nNWfOHN55552UC924Aa1awe3byW8fOxY6djR3VS1ftg5usDAZHUdnbnPnzlUfffSRUkqpkydPqrp166qYmBg1Z84c9fnnnyullNq/f79ydnZWcXFx6sCBA+r111/PsvrlVDKOLn1kHN1/jh49qkqUKKEfH1ewYEH1999/p17o1i2lKlZMfjVwGxulxoxRKrUxdpnEEsbRSYvOgvXv35833niDunXrUqhQIf766y+sra3p1KkT3bt35+rVq1SpUoWaNWui0+moU6cOV65coW7duqxevZoaNWpk9ykIketER0fz2muv6TtAVa5cmS1btqT+7ykgQFsU9fp1w/Ry5eD997WhBSVKZF6lLZwEOgvm5OTE1q1bk6RXrFhRPzs6wLRp0wBtEllfX98sq58QlsjOzk4//rVJkyasW7eOokWLplzg4UNtOZ0rVwzT69aFPXsgtbLCKBLohBDCzJo3b87u3bt56aWXsE9tFYGQEOjQAfz9DdNr1oS//5YgZyYyvEAIITLg4cOHfPnll8TFxRmkN2/ePPUg9+SJNrNJ4rsoVarA7t3Ss9KMpEUnhBDpdPHiRbp168bVq1eJjo7myy+/NK7gjRvQuzecOmWYXq6cFuRKljR7XfMyadEJIUQ67N69Gw8PD/2wGS8vL/1sQ6natQsaNUoa5EqU0IJcuXKZUNu8zaIDnamLbS5fvhw3Nzfy5ctHyZIlGTx4MMHBwWatk0o8KavIceRvJNKycOFCOnXqREhICABubm4cPXpUP9tQsp4/h8mToVMnePTIcFuRItozuSpVMq/SeZjFBrpVq1YxduxYJk2ahK+vLy1atKBz587cunUr2fwHDx5kwIABDB06lPPnz7N69WqOHz/OsGHDzFKf+Om8nj59apb9icwT/zfK6BRswvLExsby4Ycf8u677xITEwNAt27dOHjwoMGMQkn4+0PTpvDll0lXIKhWDQ4cgNq1M7HmeZvFPqObMWMGQ4cO1QeqmTNnsnPnTubOnZvskhhHjhyhQoUKjB49GtC64L/33nt8//33ZqmPtbU1BQsWJCgoCIB8+fLJ7Pk5jFKKp0+fEhQURMGCBVOeoknkSU+ePKFfv35s2rRJnzZ+/Hi+//775L8rjx+Dtzds3w5//glRUUnz9OoFS5eCi0um1VtYaKCLX2xzwoQJBumpLbbp6enJpEmT2LZtG507dyYoKIg1a9bQtWtXs9WrxIsBn/HBTuRMBQsW1P+thAAICAigS5cu+Pn5AdoP1zlz5vDuu+8mX+DTT+HHH+HFJM5JWFvD11/DJ5/I5MxZwCIDXXoW2/T09GT58uX06dOHyMhIYmJi6NGjR6prwUVFRRGV4FdaeHh4qvXS6XSULFmS4sWLZ+uq4SJltra20pITSTg5OelvVbq4uLBmzRratWuXfOZ9+yC1O0E1a8KyZeDubv6KimRZZKCLZ8pim/7+/owePZrJkyfTsWNHAgIC+Pjjjxk+fDheXl7Jlpk+fTpTp041uV7W1tZyMRUiFylQoABbtmyhb9++eHl5pT6d18aNyadbWcGYMVpLzoglsIT5WGSgS89im9OnT6dZs2Z8/PHHgLYwqZOTEy1atOCrr76iZDLjWiZOnMj4BGtF3b17l1q1apnxTIQQ2UEpRXh4OAUKFNCnlS9fnoMHD6b9bD3R2oe4u0P//tCjB1SoYP7KijRZZK/L9Cy2+fTpU6ysDD+O+FZXSt3N7e3tKVCggP7l7OxshtoLIbJTdHQ0Q4YMoXXr1kRERBhsSzPI3bsH588bps2aBaNHS5DLRhYZ6EDrDbVo0SIWL17MhQsXGDdunMFimxMnTmTAgAH6/N27d2fdunXMnTuXa9eucejQIUaPHk3jxo0pVapUdp2GECILBQcH0759e5YuXcqpU6cYMGCAaeMqXywsrOfiAi+9ZN5KCpNZ5K1LSHuxzYCAAIMxdYMGDSI8PJxff/2VDz/8kIIFC9KmTRu+++677DoFIUQWunTpEt26dePff/8FwMHBgT59+pg2DCjxbcvWrcHGYi+zuUc2roVncSxhgUIh0is3L7y6Z88eVbBgQf1Cqa6ururIkSOm7SQuTqmSJQ0XTJ09O3MqnIUycl375ptvFKDGjBlj/oqZwGJvXQohhDG8vLzo0KGDfjqvunXrcvToUZo0aWLajvz9tQVUE0ppCEIecPz4cRYsWEC9evWyuyqW+4xOCCFSExsbyyeffMKwYcP0Y+S6du3KoUOH9I84TJL4tmW5clC1qhlqmvvEzyKzcOHC1Of/zCIS6IQQedLvv//ODz/8oH8/ZswYNm7cmP7e04kDXfv2eXbWk5EjR9K1a9eUB9VnMXlKKoTIk/r378/69evZunUrv/zyC++//376dxYdDfv3G6blkIu8uYSHhxMWFqZ/b29vn+zCsitXruTUqVMcP348K6uXKmnR5SFDlx5n6NKc8+UzN0s/v+xmaZ+vtbU1y5cvZ8+ePRkLcgBHjkCiMXe0bZuxfeYwtWrVwsXFRf9KbnL827dvM2bMGP744w8cHByyoZbJkxadECJP2LBhA6VKlaJx48b6tPz58/Pyyy9nfOczZxq+b9AAihXL+H5zEH9/f0qXLq1/n1xr7uTJkwQFBdGoUSN9WmxsLAcOHODXX38lKioqW6Y/lEAnhLBoSil++OEHJkyYQPHixTl27BjlzLmK9/79sH69YVrPnubbfw7h7OxsMCVactq2bcvZs2cN0gYPHkyNGjX49NNPs22OXwl0QgiLFR0dzfvvv8/ixYsBuH//PosWLWLatGnmOUBcHCSY7xaAokVh7Fjz7D+XcXZ2pk6dOgZpTk5OFClSJEl6VpJAJ4SwSI8ePaJ3797s27dPnzZt2jQ+//xz8x3kjz/g1CnDtKlTZSHVHEYCnRDC4ly5coWuXbty5coVQHue9Ntvv9GnT5+M7/zkSdi5E27dgnXrDLfVrAkpLcaaRyX8oZFdJNAJISzKvn37ePXVV3n8+DEAxYsXZ+PGjTRt2jRjOw4J0W5J/vZbynn+9z+Z2zIHkuEFQgiLsXTpUtq3b68PcnXq1OHYsWMZD3Le3lC3bupBrl076Nw5Y8cRmUICnRDCYuh0Ov10Xp07d07/dF7x4uLg//4POnSAO3dSzle4MPz6a56dCSWnkza2EMJiDBw4kEuXLhEREcGPP/6ITUZuI0ZEwMCBsHZt0m0FCsDrr2uLqVaoAJ06ab0tRY4kgU4IkWtFRETg5ORkkPb111+btoZccq5ehTfeSNqjErRblF5e2qTNIleQW5dCiFzJ19eXGjVqsHz5coP0DAW5J09g0iSoVStpkLO21mZA2blTglwuIy06IUSus3HjRvr27cvTp08ZMmQIlSpVwsPDw/QdXbwI8+fD5cvw6BFcuQLBwUnzFSwIq1db3ETNeYUEOiFErqGU4scff+STTz5BKQVAw4YNqVSpkuk7++MPeOcdiIxMPV/VqrB5M1Svno4ai5xAbl0KIXKF58+f8+677/Lxxx/rg9xbb73F3r17cXV1NX5HsbHw8cfQv3/qQc7GBsaNg+PHJcjlctKiE0LkeI8fP+a1115jz549+rQpU6YwZcoU057JnTihzU3p45N6vvbttedxtWqlr8IiR5FAJ4TI0f7991+6du3K5cuXAW06r8WLF9O3b9+0C8fFwe3bcOkSLFkCK1cmn2/gQPD01MbD1aypBTgZE2cxJNAJIXKs2NhYunfvrg9yxYoVY8OGDXh6eqZe8NkzeO89WLNG+/+U2NrCnDkwbJgZay1yGnlGJ4TIsaytrfHy8sLe3p5atWpx9OjRtIMcwIcfwu+/px7kypWDvXslyOUB0qITQuRonp6ebN26FXd3d1yMWf7m2DGYNy/l7S4u2li5Dz4ABwfzVVTkWNKiE0LkGE+fPuWnn34iLi7OIL1t27bGBbmYGBg+HF70ytRzdgZ3dy3AXb2q9bqUIJdnSItOCJEjBAQE0KNHD06cOMGDBw/45ptvTN/JnDng62uY9vXXMHGidC7Jw6RFJ4TIdqdPn6Zx48acOHECgF9//ZV79+6ZtpPDhyHx6uG1a2utNwlyeZoEOiFEttq8eTPNmjXjzotlcMqXL8/hw4cpVaqUcTvYvh2aN4dmzSA83HDb3Llaz0qRp0mgE0JkC6UUM2bMoGfPnkRERADQpEkTjh49Sp06dYzbybffQpcucOhQ0m2DB0OLFmasscitJNAJIbLc8+fPGT58OB9++KF+Oq8+ffqYNp3X/v3w2WfJb6tfH374wTyVFbmeBDohRJYKCQmhS5cuLFiwQJ82efJkVqxYgaOjo3E7efwY3n47ae/KMmVgxgw4eBCKFDFjrUVuJr0uhRBZytramqCgIADs7OxYvHgx/fr1M34HSmmznrx4pqc3cSJMnSrP5EQS0qITQmQpZ2dnNm/eTN26ddmzZ49pQc7PD4YO1daGS6hNG/jqKwlyIlnSohNCZLpnz54Z3JYsV64cfn5+WFkZ+Vv777+153HHjyfdVrgwLFsGxu5L5DnyzRBCZJq4uDg+//xzPD09efLkicE2o4JcWJh2m7J9++SDHMCiRVC6tBlqKyyVtOiEEJni2bNnDBw4kNUvbjP27duXDRs2GN+KO3BAWxz11q3kt1tZwfffwyuvmKnGwlJJoBNCmF1gYCA9e/bk2LFjgNZ6a9u2rfGLpG7cCG+8AdHRSbeVKaM9pxsyRFuBQIg0SKATQpjVmTNn6NatG7dv3wYgf/78rFy5kq5duxq3g9WroW9fbYLmhJyc4LvvtEmbra3NXGthySTQCSHM5n5QEM2aval/Hle2bFm2bNlCvXr1kmaOiYHAQG2YwO3bcPMmXLmiPXNLtHoBrVrB4sVQsWLmn4SwOBLohBAZppTi2vVr+J/31we5xo0bs3HjRkqUKAGxsfDnn7BzJ9y4oQW1u3eTBrTkDBumrS8nrTiRThLohBAZtnHjRs6f99e/f+ONN1i6dKk2pODGDa1TycGDpu945EiYNUuGDogMkW+PECLDevToobXcgM8//5w///xTC3J//AFubukLch9+CL/8IkFOZJhFf4PmzJlDxYoVcXBwoFGjRvj4+KSaPyoqikmTJlG+fHns7e2pXLkyixcvzqLaCpF7WVlZ0aBBA156yZ0vv/wSK50Oxo/XWnJhYakXtrPTnr21agUDB8LkyXDyJPzvf7KOnDALi711uWrVKsaOHcucOXNo1qwZ8+fPp3Pnzvj7+1MuhS7Jb7zxBvfv38fLy4sqVaoQFBRETOKeX0IIDh06hI2NDU2aNNGn2VhbU8L1xfO4d9/VOo8kVrEijBoFFSpA+fLa8ICiRSWgiUxlsYFuxowZDB06lGHDhgEwc+ZMdu7cydy5c5k+fXqS/Dt27GD//v1cu3aNwoULA1ChQoWsrLIQucLy5csZMmQIBQsW5OjRo4b/Tp4+hbfeSjoXJcCAAdqtyAIFsqyuQkAOCnS+vr7s2LGDyMhIqlSpQv369alVqxbW6ehpFR0dzcmTJ5kwYYJBeocOHTh8+HCyZTZt2oS7uzvff/89v//+O05OTvTo0YMvv/wyxaVDoqKiiIqK0r8PT7y6sRAWRKG4fOkyi7/tD0BQUBA/vPYas93dtWEC+RtDZBSsTRTkrK3By0u7LSlENsgRgW7z5s307t2bmJgYbGxsiI2NBbQlPOrUqUODBg1o0KAB77//vlH7e/jwIbGxsUkWcHR1dSUwMDDZMteuXePgwYM4ODiwfv16Hj58yIgRI3j06FGKz+mmT5/O1KlTTThTIXKnZ8+ecerQYe49fqxPew+YefKk9jwNoLdb0oL29vDXX9CjR9ZUVIhk5IjOKF999RXly5fn5s2b3L59G6UUo0eP5uWXX+bkyZN4eXkxatQok/ebeLohpVSKUxDFxcWh0+lYvnw5jRs3pkuXLsyYMYOlS5fy7NmzZMtMnDiR0NBQ/cvf3z/ZfELkZoGBgbSuXVsf5HTADGAukOqiOE5OsHWrBDlhkufPn9O6dWsuX75stn3miEB38eJF3nnnHcqWLYuNjdbI7N69Ozt37mTevHm4ubnp58wzRtGiRbG2tk7SegsKCkrSyotXsmRJSpcujYuLiz6tZs2aKKW4k3iBxxfs7e0pUKCA/uXs7Gx0HYXIDc6ePUsTNzeOXr8OaLeANgLj0AJesooWhTffhGPHoG3brKmosBi2tracO3fO+HlRjZAjAp21tbW+A4iDgwOgPWcDePfddylXrhzr1683en92dnY0atQIb29vg3Rvb288PT2TLdOsWTPu3btnsJTI5cuXsbKyokyZMiadjxCWYPv27TTz8ODWi9XAHQFPoDtoz91q19ZWDnjvPfi//wO3etoQgaAgbRaUWrWyr/Ii28ydO5d69erpGwAeHh5s377dpH0MGDAALy8vs9UpRzyjq1ChAjdu3ADAyckJFxcXAgIC9Nvbt2/PjBkz+Oqrr4ze5/jx4+nfvz/u7u54eHiwYMECbt26xfDhwwHttuPdu3dZtmwZoC0h8uWXXzJ48GCmTp3Kw4cP+fjjjxkyZEiKnVGEsGTBN24QHhEBgDtQDXAA+PhjmDoVEv+7WPpivTgZKpCnlSlThm+//ZYqVaoA8Ntvv9GzZ098fX2pXbu2UfuIjo5m0aJFeHt74+7ujpOTk8H2GTNmmFSnHBHo2rZty44dO/SBrF69euzatYvBgwcD8OTJE4PAZ4w+ffoQHBzMtGnTCAgIoE6dOmzbto3y5csDEBAQwK0E61zlz58fb29vPvjgA9zd3SlSpAhvvPGGScFVCIuhFG///TeXgAvAMuADgJIl4dt3ZbYSkaLu3bsbvP/666+ZO3cuR44cMTrQnTt3joYNGwIkeVaXnluaOSLQjRs3jvLly/Ps2TMcHR0ZOXIkb775Jq6urlSrVo0ZM2ZQKx23QUaMGMGIESOS3bZ06dIkaTVq1Ehyu1OIvCI6Oho7Ozvtze+/w7p1xPcptgIoVBAa1JcgJ4wWGxvL6tWriYiIwMPDw+hye/fuNWs9ckSgK1WqlEGvyjfeeIO9e/cya9YsAAoWLMjMmTOzqXZCWL7r16/TvXt3PvnkEwa0bAkffAAkeIhftCi4vwRWsoJAXhUeHk5Ygunc7O3tsbe3Tzbv2bNn8fDwIDIykvz587N+/fp0NVb+/fdfrl69yssvv4yjo2OqPedTkyMC3datW2nevLlBj8e5c+fy6aefcufOHerWrWuwTWSdofHPXQCvQS+ZXCYhY8tnRp1M2a8595lRaZ2rOT6Lw4cP06tXLx48eMCwYcOoWLs2LRLPT7lgAYQmf1HLaTLr+5HXJQ5UU6ZM4Ysvvkg2b/Xq1fHz8yMkJIS1a9cycOBA9u/fb3SwCw4O1jd4dDodV65coVKlSgwbNoyCBQvy448/mlT3HHEPokePHmzdujVJeoUKFZIEQCGE+axYsYI2bdrw4MEDACra21PSz88w08CBWu9Kkaf5+/sbjBueOHFiinnt7OyoUqUK7u7uTJ8+HTc3N37++WejjzVu3DhsbW25desW+fLl06f36dOHHTt2mFz3HBHolFKpbt+yZUuSB5xCiPRTSjFlyhT69eunn8aujZMTR548oUrCjOXKgQkXKGG5nJ2dDcYNp3TbMjlKKYPpEtOya9cuvvvuuyRDu6pWrcrNmzeN3k+8bLt1+ccff3Dy5EkaN24MpN6TJjQ0lG3btmVV1YSwaJGRkQwePJiVK1fq096xs2N2RIThTCc2NrBsGcgdFWGCzz77jM6dO1O2bFnCw8NZuXIl+/btM6klFhERYdCSi/fw4UOTAmy8bGvRhYSEMGfOHPr164dOp2Pw4ME0atSIYcOGMXv2bA4fPkzEizE8Z8+epVChQtlVVSEsxv3792ndurU+yOmA/wHzo6MNg1yhQrB9O7RsmQ21FLnZ/fv36d+/P9WrV6dt27YcPXqUHTt20L59e6P38fLLL+vHOIPWEIqLi+OHH36gdevWJtcp21p0o0aN4p133uHUqVM0a9YMT09PYmJiWL16NYsXL0an06HT6ShYsCCPHz/mtddey66qCmERlFL0bNuWo+fPA5APWAH0TJyxdm3YuBEqV87iGgpLYI4ZTX744QdatWrFiRMniI6O5pNPPuH8+fM8evSIQ4cOmby/bO11aW9vj4eHBx07dmTUqFF07doVgKtXr+Lr68vp06e5ceMGFSpU4KOPPsrOqgqR6+kWLeLn8+dpCRQFNgMNEmd6802th6XM2yqyUa1atThz5gxz587F2tqaiIgIXn31VUaOHEnJkiVN3l+OGF6QeB60ypUrU7lyZWnFCWEut2/DyJE0ATYA9YBS8dvy5dN6Vo4aJfNTihyjRIkSZlsGLUcEOjDvwqtCCIiJiWHp0qUMGTIEq2+/hefPAegUn6FIERg3DkaM0J7JCZGDPH78GC8vLy5cuIBOp6NmzZoMHjxYvwCAKXJEoDP3wqtC5HVhYWG8+eabbN++nSunTvFd4ucmb70FCxdqa8YJkcPs37+fnj17UqBAAdzd3QGYNWsW06ZNY9OmTbQ0sZNUjgh08Quv7tmzBzs7O0qWLMmYMWPw9/fH29ubU6dOAUigE8IIN27coHv37pw7dw6An+bP5524uP/Gx9nZwfffS5ATOdbIkSN544039M/oQJs3c8SIEYwcOVL/3TZWjhgwbu6FV4XIq44cOUKTJk30F4LCBQvibW1tOAh86FCQNRZFDnb16lU+/PBDg0dX1tbWjB8/nqtXr5q8vxwR6My98KoQedHKlStp1aoVQS8WSq1WoQJHGjSg5YtncwDY2sKECdlUQyGM07BhQy5cuJAk/cKFC9SvX9/k/eWIW5eZsfCqEHmFAq5cvszi6W/r01q7uLDmxg0Kv/h3pTdkiDatlxA5zJkzZ/T/P3r0aMaMGcO///5L06ZNAe1uxezZs/n2229N3neOCHSZsfCqEHlBbFwcp319uZvg38dQYE5oKHaJM9vaQioT8QqRnerXr49OpzOY+/iTTz5Jkq9v37706dPHpH3niECXWQuvCmHpVMhjntwPBLTpvL4DPnrx/wasrOC776B8+aytoBBGun79eqbtO0cEOll4VQgjnToFO3ZAUBAEBWETU42X4hT/AAuAXonzFysGgwfDsGFQtWqWV1cIY5XPxB9hOSLQJUcWXhUikT/+gIEDiYmL++8fbu/JOAKteBHkHB2hUSN46SV4+WXo0kUbTiBELnP37l0OHTpEUFAQcXFxBttGjx5t0r6yJdA9ePCAYsWKpZmvQoUKVKhQIfMrJEROd/8+TBrE3Lg4FgL7gYSzUVoBNG8OK1dC6dLZUkUhzGXJkiUMHz4cOzs7ihQpYrCMm06nyx2BztXVlRIlSuDm5kb9+vX1/61evXqq69IJkecoBcHBqJMnGBsbS/wSqG8BGxPmq1wZ/vxc63AiRC43efJkJk+ezMSJE7GyyvgouGwJdFOmTOHcuXOcPXsWb29v4uLi0Ol0ODg4UKdOHdzc3PTBr169ejjLTOoiLzl9GiZPBh8faPMBMcBJ4HyCLLUrVkT36qvgWBNci0N+ZwlywmI8ffqUN9980yxBDrIx0MWLjIzk/PnzjBs3joMHD+Lv78+5c+dYtGiRvnVXsWJF6tevz5o1a7KjukJkjbg4+Okn+OwzeDFhwlPgOBD2IosNMK95c4YeOAA6HSw9nk2VFSLzDB06lNWrVzPBTJMbZHtnFAcHB3bv3s3Vq1c5cuQIjRs3BuD06dPMmjWLP/74g5CQEE6cOJHNNRUiEz14oE20vHu3PukocBCIevG+ELC2RQta792rBTkhLNT06dPp1q0bO3bsoG7dutgmulsxY8YMk/aX7YEO4Oeff2b8+PH6IAfg5uaGl5cX77zzDh06dGD+/PnZWEMhMlFsLPToAUeO6JP+AgbyX4cTJ2Bnz55UW7UKZOkqYeG++eYbdu7cSfXq1QGSdEYxVY4IdKGhodjb2ye7rWnTprz77rt88803dOzYMYtrJkQW8PIyCHJ7gfh5H5yBIoUK4t7InWrDzbMIpRA53YwZM1i8eDGDBg0yy/5yxKTOTZs25ffffzeY+iWh6tWr4+vrm8W1EiILBAcnmZarZYkSvPZiva2yZcvS1MMTuxeTnQuRF9jb29OsWTOz7S9HBLpp06bh6+vLK6+8kuw0MDt37tSvaiCERZk0CR49Mkiy+uMPftu2jcWLF+Pm5ma2nmdC5BZjxozhl19+Mdv+csStS09PT/766y8GDhxI9erV6dq1q35V2d27d7N//3769++fzbUUwsxOnoQFC7iA1quyCcDrr0PbtuQDBg8ezEHpVSnyoGPHjrFnzx62bNlC7dq1k3RGWbdunUn7yxGBDqBXr16cPXuWr776inXr1rFxozYcVqfT8frrr+vnvRQi14uNhaVL4fPP8VaK1wE74KiDAxV//DGbKydE9itYsCCvvvqq2faXYwIdQLly5ViwYAHz5s3j9u3bREREUL58eZycnLK7akJk3O3bsGULzJ0LZ88yDxgFxL7Y/Fm1avxZtmw2VlCInGHJkiVm3V+WB7pbt24RHBxMVFQUhQoVolKlSkmapVZWVpk6k7UQWUYprfU2axb4+QFaYPsImJkgW4/8+Vm4Z0+WV0+IvCBLAt2ePXv49ddf2b9/PyEhIYYVsLHBw8ODQYMG0b9/f6xljJCwFFevwjvvwN69+qRwoC+wJUG2DytU4DsfH6yLFMnqGgqRI1WsWDHV8XLXrl0zaX+ZGugeP37MwIED2bp1K0CywweeP3+Oj48PPj4+/O9//2PlypXUqVPHIM/169epWLFiZlZVCPNRCubMgY8/hmfP9Mm3gW7AmRfvbYA5Y8bwjqy1KISBsWPHGrx//vw5vr6+7Nixg48//tjk/WVaoAsJCaF58+ZcvHgRpRTOzs506NCB+vXrU7RoUZRSBAcH4+vri7e3N+Hh4fj7+/Pyyy+zd+9e3NzcALhw4QLt27fnzp07mVVVIczrq6+0SZkTOAb0BAJfvC/o5MSadeto26FDVtdOiBxvzJgxyabPnj07XdNBZlqgGzhwIBcuXMDOzo7PP/+ccePGpdipJCIighkzZvD1118TEhLC66+/zpkzZ7hw4QIdO3YkODg4s6ophHn9+GOSIAdwtUgRAl98jytXrsyWLVuoUaNGVtdOiFytc+fOTJw40eTOKpkyEtXHx4fNmzdja2vLhg0b+Pzzz1PtOenk5MT//d//sX79emxsbLh69SrDhw+nbdu2PHz4UC4IIneYOxc++ihp+ogRvHX9OlOmTKFFixYcOXJEvtNCpMOaNWsoXLiwyeUypUW3fPlyAEaNGkWnTp2MLte5c2dGjRrFzJkz9VOCeXh4sHnz5syophDm88cfMGKE/m0sYA0we7Y+fcqUKXz22WfY2dllSxWFyC0aNGhg0BlFKUVgYCAPHjxgzpw5Ju8vUwLdgQMH0Ol0vPfeeyaXff/995n54uF8jx49WLlypUz/JXK2zZshweSzD4FXgcFvvMHgBMFPp9NJkBPCCD179jQIdFZWVhQrVoxWrVql625IpgS6e/fuYW9vT7Vq1UwuW7VqVRwcHIiKimL9+vXpWpJBiCxz4AC88YY22wlwEa1n5VXgyPr1VNq/n5YvJmgWQhjniy++MOv+MiXQRUdHp7jsjjHiy0qQEzna6dPQvTtERgKwG3gNCHmxuUiRIuTLly+bKidE7mNlZZXmdV+n0xETE2PSfjMl0BUrVow7d+4QGhqKi4uLSWVDQ0MJDQ2lTJkyGa7HnDlz+OGHHwgICKB27drMnDmTFi1apFnu0KFDtGzZkjp16uD3YjYLIQzcv68FubAwABYCI4D4f35ubm5s3ryZsjKllxBGW79+fYrbDh8+zC+//JLicm6pyZRel/Fj4FKrdEriZ6WO30d6rVq1irFjxzJp0iR8fX1p0aIFnTt35tatW6mWCw0NZcCAAbRt2zZDxxcWLCoKXn0Vbt8mFvgQeJf/gly3bt3w8fGRICeEiXr27JnkVb16dZYuXcqPP/7I66+/zqVLl0zeb6YEuq5du6KUYvLkyTxKtNZWaoKDg5kyZQo6nY6uXbtmqA4zZsxg6NChDBs2jJo1azJz5kzKli3L3LlzUy333nvv0bdvXzw8PDJ0fGGhlIL334fDh3mC1ulkRoLN48aNY8OGDTg7O2dTBYWwDPfu3eOdd96hXr16xMTE4Ofnx2+//Ua5cuVM3lemBLpBgwZRunRp7t69S9u2bfn333/TLHPlyhXatm3LnTt3KFmyJIMHD0738aOjozl58iQdEs060aFDBw4fPpxiuSVLlnD16lWmTJli1HGioqIICwvTv8LDw9NdZ5HDxcXB1q3Qpg28GKz6BrDpxWZra2vmzZvHjBkzZL5WITIgNDSUTz/9lCpVqnD+/Hl2797N5s2bk0wNaYpMCXT29vYsXrwYa2trzpw5Q7169Rg2bBjbtm0jICCA6OhooqOjCQgIYOvWrQwZMgQ3NzfOnDmDjY0NXl5eGerM8vDhQ2JjY3F1dTVId3V1JTAwMNkyV65cYcKECSxfvhwbG+MeXU6fPh0XFxf9q1atWumus8jBzp2DevWgWzfYt0+f/AXgALjkz8+OHTvSNZxGCPGf77//nkqVKrFlyxb+/PNPDh8+bFS/irRk2hRg7du3548//mDo0KFERESwZMmSVKdtUUrh6OjIokWL6Nixo1nqkLj3jlIq2R49sbGx9O3bl6lTp5o0JGLixImMHz9e//7u3bsS7CxNUBC0a6d1PkmkMbB64kQq9+9PzZo1s75uQuRA06dPZ926dVy8eBFHR0c8PT357rvvqF69epplJ0yYgKOjI1WqVOG3337jt99+SzZfjlph/I033sDNzY3PPvuMjRs3EhcXl2w+KysrXnnlFb788kuzXDCKFi2KtbV1ktZbUFBQklYeQHh4OCdOnMDX15dRo0YBEBcXh1IKGxsbdu3aRZs2bZKUs7e3N2h5hr3ogScshFIweDDcv48C1qA9k7MGKFECfvqJbm++ma1VFCKn2b9/PyNHjuSll14iJiaGSZMm0aFDB/z9/dNcRHvAgAGZMqws09ejq169OmvXriUwMJB9+/Zx/vx5/STNRYoUoVatWrRu3ZoSJUqY7Zh2dnY0atQIb29vXnnlFX26t7c3PXv2TJK/QIECnD171iBtzpw57NmzhzVr1sgSQXnVr7/Ctm1EA8OBJcD4QoX48ccfoW9fyMDtdSEs1Y4dOwzeL1myhOLFi3Py5ElefvnlVMsuXbo0U+qUZSuMlyhRgjez8Nfv+PHj6d+/P+7u7nh4eLBgwQJu3brF8OHDAe224927d1m2bBlWVlZJHnQWL14cBweHDD0AFbnY2bPw8ccEo7XiDrxInvH4Mf0bNKC+BDkhjBIaGgqQrsmYzSXLAl1W69OnD8HBwUybNo2AgADq1KnDtm3bKF++PAABAQFpjqkTeVRICLzxBpejougKxPcZdrCzY9kff1C/fv3sq5sQ2SQ8PNzg8UziRzfJUUoxfvx4mjdvnq2NBosNdAAjRoxgRIJJdRNKq4n8xRdfmH2+NaEZuvS4/v+9Br2Us46v4uC119h78SK9gccvkl3z5WPT3r00btw4c49vYvn0lMuOzzy9x0/us8qu709GP7+0yhu7f3Oef0rfpeT2m7ij3ZQpU9K8Ro4aNYozZ85w8ODBdNfRHCw60AlhsrPn8Nq9m+H8N9NJXQcHtvj5Ua5q1eysmRDZyt/fn9KlS+vfp9Wa++CDD9i0aRMHDhwwy5SOGSGBTuRtSsHly+Djg/J7zoXAQBYn2NzVzo4/T57EWYKcyOOcnZ0pUKBAmvmUUnzwwQesX7+effv25YjOfBLoRN4TEwOBgfDwIUzqBffuARDXezIPE2Qba23N//bvx1rGRgphtJEjR7JixQo2btyIs7OzfpiXi4sLjo6O2VInCXQib9m+Hfacguho7f2LIAfa+LjGwHNgAjD8r7+gadNsqKQQuVf8fMKtWrUySF+yZAmDEixQnJUk0Im8IToaPvsMfvwRek/WJ8dhOA+eA3DBzg7HmTO1FQqEECZJzzI6mU0CnbB8hw7B6NFw6pRBcgDgAXgDBUqVglKloHBhHH+8DC+GoQghcr9MmdRZiBzhyhXo3RuaNzcIcgptbNxJ4BjQp0ULYm7cgIYNoUIFCXJCWBhp0QnLtGEDvPmmtkhqAtHAGSDhVAFFypUjNoV5WIUQuZ+06ITl8faGPn2SBLlHQKd8+QyC3LRp0/j9998ztCyUECJnkxadsCyPH8PIV/7rVfnCFRcXutnbczkoiGJoK2Y0qF+f//ss6STfQgjLIi06YTlCQ+DYUXj61CB5X7t2NNHpuBwUBIC9nR2eHh6UKlUqGyophMhq0qITlmHdOjh8DmJjDZJPtW9Ph337eP78OQB16tShTosW5MumgatCiKwnLTqRuykF336r9a5MFOTo0oX6mzbp1yTs3Lkzhw4dkiAnRB4jLTqRO8XFwd27UH8YnDmTdHubNrB6NVYODixdupQmTZowevRobGzkKy9EXiP/6kXuoRScPg0X/OHOHYiKThLkIoFj3bvTeM0asLMDwNHRkfHjx2dDhYUQOYEEOpEzPXsG585pK31fvaq9Tp+GixcNpvBKKBQ4ZmPDzn2HOXr7NpUrV87aOgshciQJdCLniIuDuXNhzhwtoJkwiHtjyZIcsrIiNiaG4OBgRo0axfbt2zOxskKI3EICncgZYmNh2DBIY+X3xFSrVvxYsSKfLF1K0ReBsWnTpmmuIC+EyDsk0Ins9/w59O8Pq1YZl9/REUqXJq5UKd49e49FixbpN5UuXYq9f+zFwcEhkyorhMhtJNCJbKRg716YPl2btisxnQ6qVoWaNaFyZe1Vvz5ctuH58xhOnDjBhQRBrnq1alStVk2CnBDCgAQ6kUUU7NoFJ07A41LaFF3BwbD8s6RZ7e21W5jdu4OTU5LNEb77OHbsGE8iIl5kt2fJkiX8HVUlk89BCJEbSaATme/hQ7hwARZ/qL1PodckAPnywaZN0LZtillCw8L0Qa5YsWJs2LABT09P/l563Jy1FkJYCAl0IvOEh4P/eXjw0Lj8hQvDxo3a+nGpKFWyJE+qV+fe3bv8ffQoFStWNENlhRCWSgKdML/YGLh8Ga5d01Y5TUu9evD22zBoEBQrlmSzUgqdTmeQVrVqVSpVqiRBTgiRJgl0wrx27YK9JyEyMvnt1apBmTJgbwf2DjD5tBboUvD06VMGDBhAp06dGDZsmD5dB9hYW5u58kIISySTOgvz+eUX6Nw5+SDnYA+LFsH581rPyZq1oFKlVIPcvXv3ePnll1m7di3vv/8+e/bsyby6CyEslrToRMbFxMC4cfDrr0m3WemgchWoUgWGNjV6l35+fnTv3p07d+4A2nyV0YkWUxVCCGNIoBMZExEBffrA1q1JtxUtCnXrJjtEIDWbN2/mrbfeIuJFz8py5cqxZcsW6tata44aCyHyGLl1KdIvOBjatUs+yFWrBk2bmhTklFLMmDGDnj176oNckyZNOHbsmAQ5IUS6SYtOpM/t29CxozY+LiE7O2jQAEqXNml3z58/Z9SoUSxYsECf1qdPH5YsWYKjLJQqhMgAadEJ023ZAo0bJw1yhQrBnj0mBzmAIUOGGAS5yZMns2LFCglyQogMk0AnjBcaCkOHalNzBQYabitTBg4ehGbN0rXrsWPH4ujoiJ2dHX/88QdTp07Fykq+nkKIjJNblyJ1cXHwIAju3YNRrbXOJ4nVrAk7d0LZsuk+TKNGjVi5ciVFihShWTqDpRBCJEcCnUjeo0faAqj+Om0CZkg+yHXtCr/9BkWKmLT7Bw8fULRIUYO0Hj16pLe2QgiRIrk3JAyFhMBHH0G5cvB///dfkEvM2RkWL4bNm00KcnFxcVy8dJEjR47i7+9vnjoLIUQqJNAJjVLwxx9QvTr8+GPyrTcAKyvo2RPOnoXBg7U144z09OlT3nzzTa5c+ReAa9evc+DAAXPUXgghUiSBLq979kxb2fvll7VVvoOCks9XuDDMnq09q9uwAcqXN+kwkVFRtGrVitWrVwPaXJW1a9emRYsWGau/EEKkQZ7R5UVxcXDggNaCW70awsKSz2dtrQ0VqFwZChSAQS+l63BhYWEcO36MW8e19eJsrK1p2KgRrsWLJ1mVQAghzE0CnSV69kybteTZM3j+XHvOFhAANyPgyRMo/yq8mEMyRT16wIwZ4PMoQ1W5HxTEqZMniYmNBaBs2bI0adaMAgUKZGi/QghhLLl1aQni4mDqVG3arfz5tVW6y5bV3teurc1U0qWL9lzt+vXUg1z58tripxs3ai25dFLAtevXOH7smD7INW7cmGPHjkmQE0JkKWnRWYJJk+Dbb9NfXqeDNm20Z3RvvAFmmI1ExcVx9+5d/bqrpUqWZN/v+17MdHI7w/sXQghjSaDL7f74I/1Brl496NsX+vXTZjYxIysrK1566SUOHjxImTJlqF69ukznJYTIFhZ963LOnDlUrFgRBwcHGjVqhI+PT4p5161bR/v27SlWrBgFChTAw8ODnTt3ZmFt0+HIEUiw6naKrKygWDEo6AIlS8LkyXDmDJw+DZ9+arYgp5QyeO9g70DLli2pUb0GOqTTiRAie1hsoFu1ahVjx45l0qRJ+Pr60qJFCzp37sytW7eSzX/gwAHat2/Ptm3bOHnyJK1bt6Z79+74+vpmcc2NdO8evPIKREUZpn/3HVy8qHVGiYyE2FjtFRQEzVtAo0ba8zwzL3tz6NAhWrduTWhoqEG6rY2tWY8jhBCmsthAN2PGDIYOHcqwYcOoWbMmM2fOpGzZssydOzfZ/DNnzuSTTz7hpZdeomrVqnzzzTdUrVqVzZs3Z3HNjTRyZNKJlUeNgk8+0QZ9Fy4M9vZaay6TLV++nDZt2rB//37eeOMN4hK17IQQeceBAwfo3r07pUqVQqfTsWHDhuyukmU+o4uOjubkyZNMmDDBIL1Dhw4cPnzYqH3ExcURHh5O4cKFU8wTFRVFVIIWVXh4OKDNABKR0swi5rB9uzZoO6HWreGrr1Ke0QR4HvUMwKS6xZdJrlxcXBxff/0133333X/5nz8n6ukTbGySfrXiy6e2z4zUydjzy2j5jDLl/JPLmzAtIWP3ld7zS6t8RrenViZhubQ+v4x+v9KqS3Z9fonzZaQuye0roYT7ffr0qUn7jIiIwM3NjcGDB9O7d+8M1c9slAW6e/euAtShQ4cM0r/++mtVrVo1o/bx/fffq8KFC6v79++nmGfKlCkKrSe9vOQlL3lZ9Ov27dsmX4sBtX79epPLmZvF3roEksy6oZQyaiaOP//8ky+++IJVq1ZRvHjxFPNNnDiR0NBQ/UsmKRZCiJzHIm9dFi1aFGtrawITPcMKCgrC1dU11bKrVq1i6NChrF69mnbt2qWa197eHnt7e/37sBdTaV26dInS6VhlO00nTkC7dhAT819as2awY4dRkyu//8dJAOa+3cjoQ8aXiS937tw5XnvtNe68GHSeL18+fvvtNzp37pxsmYTij5t4n6ZKqbyx55fR8hllyvknlzetzzetfaX3/NIqn9HtqZVJWC6tzy+j36+06pJdn1/ifBmpS3L7Sijhfu/evUv16tUJDw/XX+Mg6fUvJ7PIQGdnZ0ejRo3w9vbmlVde0ad7e3vTs2fPFMv9+eefDBkyhD///JOuXbum+/j58uXDyckp3eWTiI3VVhT4/HPDIGdjA/Pna7OhGMHWXhvHllLdhi7V5qL0SjCnZXwZgCFLj+Pjc4CAF0GuTJkyNP14KdufFGD7an99uYRlEhq92j/J9vg0UyQsn/Bc4tNT2mdy9UuY19jPJyXx+08rX0rH90pmLtHkzjWlzzet71xan09q9UipfHLflYT1SPhZpLU9tX0mPG5a35+Uvh8ZZeznl1Ban09a+09YPv6zMuf5GfNdypcvHwC1atUyyDNlyhS++OKLDB0/q1hkoAMYP348/fv3x93dHQ8PDxYsWMCtW7cYPnw4oN12vHv3LsuWLQO0IDdgwAB+/vlnmjZtqm8NOjo64uLikrWVj46Go0e1KbsuX4aDB+FkMr+8PvxQm+Irizg5OeHq6koA8NJLL7Fx40Y+35nGnJlCCIvg7+9vcKcqt7TmwIIDXZ8+fQgODmbatGkEBARQp04dtm3bRvkXy8sEBAQYjKmbP38+MTExjBw5kpEjR+rTBw4cyNKlSzO/wjExsGQJbNoEe/em2nsS0G5ZTp6c+fVKQAe4udWnx+TJfPrppy9+6UmgEyIvcHZ2zrXz1FpsoAMYMWIEI0aMSHZb4uC1b9++zK9QSiIioEMHMGbog06nzWYydSrY2WVqteI72SRs0VpbWTF16tRMPa4QIvd68uQJ//77r/799evX8fPzo3DhwpQrVy5b6mTRvS5zhdhYbb5JY4Jc+fKwbx9Mn57pQe769et4enpy5MiRTB9XJoSwHCdOnKBBgwY0aNAA0B4jNWjQgMlZfAcqIYtu0eUK48drtyuTU7eu9gyuWjVtAuauXcHBIdOrdPjwYXr16sWDBw8oVvM5vn5+NGvWTGarFEKkqVWrVknmvc1uEuiy06xZ2iuhQoW0tA4dIJUxfJnl7t27tBn+pn7Gl/xOTjSoX1+CnBAi15JAl12uXtV6TSZkZ6dN7fXyy1leHaUUly5f4vLlK/og16ZNG0o3b46trUzMLITIveQZXXb56SfDMXGg9brMhiAXGRlJ3759uXz5ij7tnXfeYceOHRLkhBC5ngS67PDwISxebJj2wQdap5Qsdv/+fVq3bs3KlSsBbQjB//73P+bPny9BTghhEeTWZXaYOxeeJZg13MYGPv44W6py5MgRjhw5AoC1tTUNGzbgww+7Z0tdhBAiM0iLLqtFRsIvvximvfUWlC2bLdXp2bMnX3/9NaVLl6ZZM09KuJbIlnoIIURmkUCX1ZYtgwcPDNMSd0rJYhMnTuTMmTO4FMjiqc6EECILSKDLKs+fw5Yt2mDvhNq3Bze3LKlCnFKcO3eO+fPnG6TrdLpUF5gVQojcTJ7RZYbFiyEuDoKDtY4nDx5oEzQHBSXNm0XP5sLCwjh+7BhBDx4wcubXVK5cOc1liIQQwhJIoMsMU6YYl69ePW19uUx248YNunXrRlANbVl7KyurJGv1CSGEpZJbl9mlUCGYM8eoBVMz4p9//qFJkyacP38eADtbW7y9vXn77bcz9bhCCJFTSKDLak2bwrx5cO2attROJlq5ciWtW7cm6MUtUycnJ5o3b07Lli0z9bhCCJGTyK3LzNC4MZQuDUWKQNGi2qtYMWjSBKpXz/TDK6X48ssvmZLgFmrr1q0p3bw5djIIXAiRx0igywxr10KZMtl2+I8++ogZM2bo3w8dOpQ5c+bw/orT2VYnIYTILnLr0gK9/fbb5MuXD51Ox/fff8/ChQuxy+T164QQIqeSFp0FatCgAStXriQ2NpZevXpld3WEECJbSaCzAMeOHaNhw4bY2Pz35+zeXearFEIIkFuXud7cuXPx9PRk/Pjx2V0VIYTIkSTQ5VKxsbGMGTOGESNGEBsbyy+//MKWLVuyu1pCCJHjyK3LXCg8PJw333yTbdu26dM++eQTunTpko21EkKInEkCXS5z8+ZNunfvztmzZwGwsbFh3rx5DB06NJtrJoQQOZMEulzk6NGj9OzZk/v37wNQqFAh1q5dS+vWrbO5ZkIIkXPJM7pc4q+//qJVq1b6IFelShWOHDkiQU4IIdIggS4XiI2N5aeffiIyMhKAli1bcuTIEapVq5bNNRNCiJxPAl0uYG1tzYYNGyhXrhyDBg1i165dFClSJLurJYQQuYI8o8slXF1dOX78OMWKFUOXyUv7CCGEJZEWXQ504cIFunTpwuPHjw3SixcvLkFOCCFMJIEuh/H29sbDw4Pt27fz+uuv8/z58+yukhBC5GoS6HKQefPm0blzZ0JDQwEIDg4mJCQkeyslhBC5nAS6HCA2NpZx48bx/vvvExsbC0CPHj3w8fGhWLFi2Vw7IYTI3STQZbPw8HB69erFzJkz9WkfffQR69atI3/+/NlXMSGEsBDS6zIb3b59m27dunHmzBlAm85r7ty5DBs2LJtrJoQQlkMCXTa5e/cujRs3JjAwEICCBQuydu1a2rRpk801E0IIyyK3LrNJqVKlaNeuHQCVK1fmyJEjEuSEECITSIsum+h0OhYtWkSxYsWYNGmSzHQihBCZRFp0WSQqKkq/tE48e3t7ZsyYIUFOCCEykQS6LPDw4UPat29Py5YtuXz5cnZXRwgh8hQJdJns4sWLNG3aFB8fHx4/fszrr79OXFxcdldLCCHyDAl0mWj37t14eHhw9epVAEqUKMGiRYuwspKPXQghsopFX3HnzJlDxYoVcXBwoFGjRvj4+KSaf//+/TRq1AgHBwcqVarEvHnz0n3sBQsW0LFjR/0UXm5ubhw7doyXXnop3fsUQojcwtTrb2ay2EC3atUqxo4dy6RJk/D19aVFixZ07tyZW7duJZv/+vXrdOnShRYtWuDr68tnn33G6NGjWbt2rcnHnjZtGu+9955+Oq9u3brh4+ND2bJlM3ROQgiRG5h6/c1sFhvoZsyYwdChQxk2bBg1a9Zk5syZlC1blrlz5yabf968eZQrV46ZM2dSs2ZNhg0bxpAhQ/jf//5n8rEXLlyo//9x48axYcMGnJ2d030uQgiRm5h6/c1sFhnooqOjOXnyJB06dDBI79ChA4cPH062zD///JMkf8eOHTlx4kSKS+VERUURFhamf4WHh+u3WVtbM2/ePGbMmIG1tXUGz0gIIXKH9Fx/M5tFDhh/+PAhsbGxuLq6GqS7urrqp9xKLDAwMNn8MTExPHz4kJIlSyYpM336dKZOnZok3cnJiQULFvDyyy9z586dDJyJeUWEa8v/pFSn5LbHpyWU0vb49OTKZJa06ppcXmPzJWau/ZtyXFM+37S+a8bWy5TzT+7zT+/3x9jtpjDnv7/01CWtzyet/ZvyWaWHMd+lgIAAAEJDQylQoIA+3d7eHnt7+yRl03P9zXTKAt29e1cB6vDhwwbpX331lapevXqyZapWraq++eYbg7SDBw8qQAUEBCRbJjIyUoWGhupfO3fuVIC85CUveVn8a8qUKWa7/mY2i2zRFS1aFGtr6yS/HoKCgpL8yohXokSJZPPb2NikOHNJ4l807u7uAJw7dw4XF5eMnEKuEh4eTq1atfD3989TzyLlvOW884LQ0FDq1KnD9evXKVy4sD49udYcpO/6m9ksMtDZ2dnRqFEjvL29eeWVV/Tp3t7e9OzZM9kyHh4ebN682SBt165duLu7Y2tra9RxbWy0j7Ns2bIGTXxLFxYWBkDp0qXlvPMAOe+8dd7x51q4cGGjzjs919/MZpGdUQDGjx/PokWLWLx4MRcuXGDcuHHcunWL4cOHAzBx4kQGDBigzz98+HBu3rzJ+PHjuXDhAosXL8bLy4uPPvoou05BCCFypbSuv1nNIlt0AH369CE4OJhp06YREBBAnTp12LZtG+XLlwe0B6wJx3RUrFiRbdu2MW7cOGbPnk2pUqWYNWsWvXv3zq5TEEKIXCmt62+Wy5YngxYqMjJSTZkyRUVGRmZ3VbKUnLecd14g5517z1unlFLZE2KFEEKIzGexz+iEEEIIkEAnhBDCwkmgE0IIYdEk0AkhhLBoEuhMlJ1r3GUnU8573bp1tG/fnmLFilGgQAE8PDzYuXNnFtbWfNK7ptahQ4ewsbGhfv36mVvBTGLqeUdFRTFp0iTKly+Pvb09lStXZvHixVlUW/Mx9byXL1+Om5sb+fLlo2TJkgwePJjg4OAsqm3GHThwgO7du1OqVCl0Oh0bNmxIs0yuvKZld7fP3GTlypXK1tZWLVy4UPn7+6sxY8YoJycndfPmzWTzX7t2TeXLl0+NGTNG+fv7q4ULFypbW1u1Zs2aLK55xph63mPGjFHfffedOnbsmLp8+bKaOHGisrW1VadOncrimmeMqecdLyQkRFWqVEl16NBBubm5ZU1lzSg9592jRw/VpEkT5e3tra5fv66OHj2qDh06lIW1zjhTz9vHx0dZWVmpn3/+WV27dk35+Pio2rVrq169emVxzdNv27ZtatKkSWrt2rUKUOvXr081f269pkmgM0Hjxo3V8OHDDdJq1KihJkyYkGz+Tz75RNWoUcMg7b333lNNmzbNtDpmBlPPOzm1atVSU6dONXfVMlV6z7tPnz7q888/V1OmTMmVgc7U896+fbtycXFRwcHBWVG9TGPqef/www+qUqVKBmmzZs1SZcqUybQ6ZiZjAl1uvabJrUsjZdUadzmNOdaWiouLIzw83GBC2Jwuvee9ZMkSrl69ypQpUzK7ipkiPee9adMm3N3d+f777yldujTVqlXjo48+4tmzZ1lRZbNIz3l7enpy584dtm3bhlKK+/fvs2bNGrp27ZoVVc4WufWaZrFTgJlbVq1xl9OYY22pH3/8kYiICN54443MqGKmSM95X7lyhQkTJuDj46Of4Du3Sc95X7t2jYMHD+Lg4MD69et5+PAhI0aM4NGjR7nmOV16ztvT05Ply5fTp08fIiMjiYmJoUePHvzyyy9ZUeVskVuvadKiM5FOpzN4r5RKkpZW/uTSczpTzzven3/+yRdffMGqVasoXrx4ZlUv0xh73rGxsfTt25epU6dSrVq1rKpepjHl7x0XF4dOp2P58uU0btyYLl26MGPGDJYuXZqrWnVg2nn7+/szevRoJk+ezMmTJ9mxYwfXr1/PtomLs0puvKblzp+d2SCr1rjLaTKyttSqVasYOnQoq1evpl27dplZTbMz9bzDw8M5ceIEvr6+jBo1CtACgFIKGxsbdu3aRZs2bbKk7hmRnr93yZIlKV26tMEajDVr1kQpxZ07d6hatWqm1tkc0nPe06dPp1mzZnz88ccA1KtXDycnJ1q0aMFXX32VY1s3GZFbr2nSojNSwjWWEvL29sbT0zPZMh4eHknym7rGXXZLz3mD1pIbNGgQK1asyJXPLEw97wIFCnD27Fn8/Pz0r+HDh1O9enX8/Pxo0qRJVlU9Q9Lz927WrBn37t3jyZMn+rTLly9jZWVFmTJlMrW+5pKe83769ClWVoaXUGtra+C/Vo6lybXXtGzqBJMrxXc/9vLyUv7+/mrs2LHKyclJ3bhxQyml1IQJE1T//v31+eO74o4bN075+/srLy+vXNEVNzFTz3vFihXKxsZGzZ49WwUEBOhfISEh2XUK6WLqeSeWW3tdmnre4eHhqkyZMuq1115T58+fV/v371dVq1ZVw4YNy65TSBdTz3vJkiXKxsZGzZkzR129elUdPHhQubu7q8aNG2fXKZgsPDxc+fr6Kl9fXwWoGTNmKF9fX/2QCku5pkmgM9Hs2bNV+fLllZ2dnWrYsKHav3+/ftvAgQNVy5YtDfLv27dPNWjQQNnZ2akKFSqouXPnZnGNzcOU827ZsqUCkrwGDhyY9RXPIFP/3gnl1kCnlOnnfeHCBdWuXTvl6OioypQpo8aPH6+ePn2axbXOOFPPe9asWapWrVrK0dFRlSxZUvXr10/duXMni2udfnv37k3136qlXNNkmR4hhBAWTZ7RCSGEsGgS6IQQQlg0CXRCCCEsmgQ6IYQQFk0CnRBCCIsmgU4IIYRFk0AnhBDCokmgE0IIYdEk0AkhhLBoEuiEEEJYNAl0QgghLJoEOiGEEBZNFl41o7i4OO7du4ezs3OOXm1XCCGMpZQiPDycUqVKJVl/L7eQQGdG9+7do2zZstldDSGEMLvbt2/nmoV0E5NAZ0bOzs4A3AYKFCsGO3ZAlSppF7xzB377DTZvBjs7mDgROnfO3MoKIYQRwsLCKFu2rP76lhvJenRmFBYWhouLC6FAAYDSpWH/fqhcOfkCN2/CmDFagIuLM9z28cfwzTdgY8Rvkfv34Zdf4MgR8PSECRMgX74Mno0QQiS4roWGUqBAgeyuTrpIoDOjJIEOoFw5OHAAypc3zBwUBPXrQ0BAyjts0QJWroRSpZLffucOfPcdLFoEkZH/pbdrB5s2gaNj+k9GCCGwjECXO58s5ia3bkGbNlpQSuiLL1IPcgA+PtC0KVy6lHTb3r1Qqxb8+qthkAP4+2949dWk6UIIkQdJoMsMdesavr92TQt28YHt4kVYsMAwT/788MYb2jO6hG7f1lp2p079l3bkCHTvDuHhKddhxw547TWIjk7/eQghhAWw6EA3Z84cKlasiIODA40aNcLHxyfFvAEBAfTt25fq1atjZWXF2LFj03/gjRuhTh3DtCtXtGB37hx8+inExv63zcEBzp+HVavg4EHtdmdCDx5Aq1YwYwasWaN1VImIMMxjYwNOToZpW7dC//5Jn/8JIUQeYrGBbtWqVYwdO5ZJkybh6+tLixYt6Ny5M7du3Uo2f1RUFMWKFWPSpEm4ubll7OBFimi3D2vUMEy/eBEaNNCenyX04Yf/BbeXXoKTJ7X/JhQeruV7/XUICTHc1r07XL0Ku3dD4p5Rf/2ldXiRR7FCiDzKYjujNGnShIYNGzJ37lx9Ws2aNenVqxfTp09PtWyrVq2oX78+M2fONOmYSR7aBgRAy5Zaay4lxYrBv/9C4oe84eHQqxfs2ZP6QTt3hg0b/rvleegQdOyYtMX39dfw2WcmnY8QQkhnlBwqOjqakydP0qFDB4P0Dh06cPjwYbMdJyoqirCwMIOXgZIltUBVs2bKO5k6NWmQA61ltnWrFuxS0qoVrF1r+FyvWTNYvx5sbQ3zTpoECYK+EELkFRYZ6B4+fEhsbCyurq4G6a6urgQGBprtONOnT8fFxUX/SnZWlDJltFuRkyYlHRNXvToMG5byARwctEC2ejUMHAj16v23j27dUh5C0L49LFuWNH3ECPj5Z+NPUAghLIBFBrp4ieebVEqZdQ7KiRMnEhoaqn/dvn07+YyOjvDVV+Dnp93KBO2W5YoVSVteiVlZab0nly6F06e1W5qPH2tBLrWZCt58M/mgNnYsfPutEWcnhBCWwSKnACtatCjW1tZJWm9BQUFJWnkZYW9vj729vfEFateGffu0XpSFC4O1tekHdXDQXsYYPVoLil98YZg+caI2K8sPP2jDGoQQwoJZZIvOzs6ORo0a4e3tbZDu7e2Np6dnNtUqgWLF0hfk0mPKFEiu8828edoQiL//zpp6CCFENrHIQAcwfvx4Fi1axOLFi7lw4QLjxo3j1q1bDB8+HNBuOw4YMMCgjJ+fH35+fjx58oQHDx7g5+eHv79/dlTfvCZMgOR6kN68qT3PGzpUa/kJIYQFsshblwB9+vQhODiYadOmERAQQJ06ddi2bRvlX8w5GRAQkGRMXYMGDfT/f/LkSVasWEH58uW5ceNGVlY9c4wZo/XuHDkSnj0z3LZ4MWzbpk0n1rt39tRPCCEyicWOo8sOuWK8yb//aj099+9PfrubG7zyijasoV49kAVkhcjTcsV1LQ0We+tSpKBKFW1s35w5yXdEOX1a67xSvz40aaLNmSm/hYQQuZgEurzIygrefx/8/aFr15TzHT+uzbzSvLm21JAQQuRCEujysrJltUVfV67UFolNyeHD2vi/kSPhyZOsq58QQpiBBLq8TqeDPn20Hpj792sDypOb4QW0251ublpwTG2JICGEyEGkM4oZWcJDWwBiYrQpxL78ElLqcWplpQ2At7fXBsA/eABRUf89zytRArp00RaAbdNGyyeEyHUs4bomgc6MLOELYSA6WpsI+rPP4OnT9O+nQAF4+23tuWDidfqEEDmaJVzX5NalSJmdnTb+zs8PMjKjTFiYdtuzbl1ttfRDh8xWRSGESIsEOpG2qlW1XpezZ2sLwiZehcEUBw9C69awZYv56ieEEKmQW5dmZAlNfKM8e6YtPXTmjLb6QvHi2vyd+fJpnVueP9cmr16/XuuxmRw7O9i4ETp1ytKqCyFMYwnXNbMFulu3bhEcHExUVBSFChWiUqVK2Ka1BI2FsYQvhNndugULF2qv+/cNt9nbay27du2yp25CiDRZwnUtQ7cu9+zZw6uvvkqRIkWoWLEi7u7uNGvWjFq1apE/f35atWrF0qVLiY2NNVd9RW5TrpzWe/PWLRg0yHBbVJQ2IP3zzyEyMluqJ4SwfOlq0T1+/JiBAweydetWQFvQNNmdv5gnsWbNmqxcuZI6iXrcXb9+nYoVK5p6+BzLEn75ZKrYWG2l9OXLk26rXl3rkXn5stby8/TUenyWKJH19RRC6FnCdc3kQBcSEkKzZs24ePEiSimcnZ3p0KED9evXp2jRoiilCA4OxtfXF29vb8JfDCwuWLAge/fuxc3NDYALFy7Qvn177ty5Y/6zyiaW8IXIdDEx2lCDVavSzluhgjbXZvXqmV4tIUTyLOG6ZnL3uYEDB3LhwgXs7Oz4/PPPGTduHE5OTsnmjYiIYMaMGXz99deEhITw+uuvc+bMGS5cuEDHjh0JDg7O8AmIXMbGBv74Qwte33yjBb6U3Lihtew2b87Y8AYhRJ5mUovOx8eHli1bYmtry8aNG+lkZI+57du307NnT2JjY+nfvz+bNm0iJCSEmjVrcv78+XRXPqexhF8+WerMGW3R1xMnUs/n4ACrV0O3bllTLyGEniVc10zqjLL8xbOVUaNGGR3kADp37syoUaNQSvH7778TEhKCh4cHPj4+ptVWWJZ69eCff2D+fOjXDz76SPt/d3fDfJGR2hp5xtzuFEKIRExq0dWqVYtLly5x4cIFqlWrZtKBrly5QvXq1dHpdHTv3p2VK1fi4OBgcoVzMkv45ZMjPHmiTTS9bZthuk6nDVMYOjR76iVEHmQJ1zWTAl3BggWJjo7maTrnPcyXLx9RUVHExMToe2RaEkv4QuQYMTHwzjuwdGnSbR9+CNOmaQPUhRCZyhKuaybduoyOjsY+A7PQ29vbY29vb5FBTpiZjQ14ecEHHyTd9uOP2nJB+/dnfb2EELmOSYGuWLFihIWFERoaavKBQkNDCQ0NpWjRoiaXFXmUlRX8/LO2ekJi//4LrVppQxWuX0+6PSZGmzx6xw64ezfTqyqEyLlMGl7g5ubGnTt3WL9+PYMSz3KRhnXr1un3IYTRdDr4+mttPs1PPtGWDkpo+XL46y9t1pUyZbT8/v5agAsJ0fJYWWlzag4bBu3bQ/78WX0WQohsZNIzuvnz5/P+++9TpkwZ/Pz8KFy4sFHlgoODadCgAXfv3mX27NkMHz483RXOySzhXnaO5u+vdUQ5ciRj+ylVCqpV0xaFHT5cm5jaHMLCYM8e2L0b/v4brlyBkiW1hWfbtNGmOytePOXyjx5pwblcuYytECGEGVnEdU2ZIDIyUpUpU0ZZWVmp+vXrqytXrqRZ5vLly8rNzU3pdDpVunRpFRkZacohc5XQ0FAFqNDQ0OyuiuWKiVFq5kylChRQSlvPPGOv5s2Vuncv9WPGxSl15IhSu3crlfj7GxCg1Jw5SnXsqJStberHcnBQasYMbX+J/fLLf+UdHJRyd1dq5Eilrl0z32cnRDpYwnXNpECnlFK7du1Stra2ysrKSjk6OqqhQ4eqrVu3qnv37qmoqCgVFRWl7t27p7Zs2aIGDx6sHB0dlU6nU7a2tmrHjh2ZcQ45hiV8IXKNBw+UGjdOKTu7tINLWsHO1VWp/fuTP05goFKdOv2Xt2xZpby8lLpyRal33kk7uCX36tJFqaCg/46xeHHKefPlU8rHJ2s+UyGSYQnXNZMDnVJKrVq1SuXPn1/pdDplZWWV6kun06l8+fKpFStWmLvuaZo9e7aqUKGCsre3Vw0bNlQHDhxINf++fftUw4YNlb29vapYsaKaO3euScezhC9ErnP9ulKffabUa68p1bu3Uq+8olS/fkotWKDUnTtKPXmiBZJmzZTS6VIOKNbWSv30k2Fra+dOLQiao+WY+FWihFLffKPUsmXasVPL6+ys1NGjWp2uXtValiEh2fFpizzIEq5r6Qp0Sil18eJF9eqrrypra2ul0+mSfVlbW6vevXsrf39/c9bZKCtXrlS2trZq4cKFyt/fX40ZM0Y5OTmpmzdvJpv/2rVrKl++fGrMmDHK399fLVy4UNna2qo1a9YYfUxL+EJYtGfPlDp3TqmVK5UqXz75oDJwoFJ79yr1+uvpC2B2dkq1bavU9Onafn79VamePTMeGAsWVKpmzf/eFy/+X/ATIhNZwnUtwwuvBgYGsm/fPs6fP6+fpLlIkSLUqlWL1q1bUyKblllp0qQJDRs2ZO7cufq0mjVr0qtXL6ZPn54k/6effsqmTZu4cOGCPm348OGcPn2af/75x6hjWsRD27wiOFgbmrBjR8b3ZW+vdWx55RWtd6ezc9I83t7Qv3/SxWcTGz8eunSBGTOSzgyTWMGCWueXBg3SXXUh0mIJ17UMd+0qUaIEb775pjnqYjbR0dGcPHmSCRMmGKR36NCBw4cPJ1vmn3/+oUOHDgZpHTt2xMvLi+fPnye7WnpUVBRRUVH692FhYQDUqFEDK6vUhyg2bNiQTZs2GaT16NGDU6dOpVoOYPz48YwfP17/Pjw8nJo1a6ZZDmDjxo00atRI/37Lli1G9YLNnz8/Fy9eNEj7+OOP+fPPP9Ms27VrV+bPn2+Q5u7uTmBgYJplv//+e/r27at/f+nSJdq2bZtmOYDjx49TsmRJ/fsFCxYwbdo0w0zOzvBiKal41YA9ifbVr1Qp9kdGanmfP/9vQ/782j4OHIADB3jH358pU6YYlC1Tpoz2P1ZW2gTVKSwy+0fHjrT63/+0IRLNm7OvRQvePn485RMMCdHmBS1alDuJAujUqVNZuHBhymVfaNmypX4O23ht2rTh8uXLSTM/f64tlmtjAw4OTJ48mXfffVe/OSAggJdeeinNYwLs3r2b6gmWX1qxYgWffPJJmuVKlCjBiUSTgL/33nv6tTFT89Zbb/HDDz8YpNWoUYMnT56kWXbevHl0SzCp+MmTJ+nZs2ea5UBbksw5wY+fGTNmMGPGjDTLZeo1Qimtl3D89Usp7Xvn4MDGbdto1Ly5PusOc/wYzGZZ1oc5Li6OrVu34uXlxYYNGzL1WA8fPiQ2NhZXV1eDdFdX1xQvroGBgcnmj4mJ4eHDhwYXzHjTp09n6tSpSdIDAgLSrGPZsmWTpD148IC7Rgxujg+o8ZRSRpUD7UdAQs+ePTOqrHMyrZTHjx8bVfbRo0dJ0gIDA40qm3i6uZiYGKPPNfHK9k+ePDGqrEvCN05O8PXXPNy2jbu7diXN/OSJ9nohuckUjK1v1AcfaBcbAHt7oiZN4m6vXqkXiouDoCBtGEP58lprcOxYQkNDjTruw4cPk6Tdv3/fqLJPHj82eB8bG2v0ucYkWp7p6dOnRpdN7NGjR0aVfZyovgD37t3Tr5mZmmfPnhm8j46ONrq+iW+ahYWFGVU2W64Rz58T/eabsGIFvPwykPTcc6NMD3SXL19m8eLFLFu2jPtp3bYxs8RTjSmlUp1+LLn8yaXHmzhxosGvprCwMMqWLUvJkiXTbNEVK1Ys2bTSpUunWg5IcvtAp9MZVQ7Azs7O4L2jo6NRZfMnM8i6UKFCRpVNbrylsbe08yWaz9LGxsboc7W2tjZ4nz9//pTLxsTAw4cQG4sraIu+jhqljdsrWJCix44ZdVwXF5ckaSmWU0r7Ra3Tgb099onWdbR3caF0qVL/tSJtbbUWYcJf4vECA7XX0aOwZg0u7doZHjc2VrttmuiiW/TiRW18Yq1a+jRXV1ctYMfEaLd4U1gzMP+iRdp8pC/+vtbW1kb/bWwSjRPMly+fUWWT+94ULlzYqLKFChVKklaqVCmjWnSOjo4G7+3s7Iw+18TXjwIFChhVNlOvEffvp/h3tbt7F1q2hPffh88/T3LuuVJmPPiLiIhQS5YsUS1atDDofRnfSzOzRUVFKWtra7Vu3TqD9NGjR6uXX3452TItWrRQo0ePNkhbt26dsrGxUdHR0UYd1xIe2uZpkZFKrV+vdSKJicnu2qTsyROlWrRIe8hEfGeVuDilOndOOa+VlVLvvquNCYy3dq1S+fOn3UmmenUZ65fbhIdrf3MjO1eFDhmS669rJs11mZYjR47w7rvvUrJkSYYOHcrBgwdRSlGgQAEGDBhgzkOlys7OjkaNGuHt7W2Q7u3tjWcKK1V7eHgkyb9r1y7c3d2TfT4nLJC9PfTqpc2hmag1mKM4OcHWrdCz53+3OhO7f1/7Vf7zz/D777B9e8r7i4uDBQugShVo3BiaN4fevQ1uyabo0iXt87p5M12nIrKBn5/2N49nbQ3LlkGzZknzRkfD4sVZVrVMk9FIGRQUpH788UdVq1Ytg9abra2t6t69u1q9erWKjIxUT548ybIWnVL/DS/w8vJS/v7+auzYscrJyUnduHFDKaXUhAkTVP/+/fX544cXjBs3Tvn7+ysvLy8ZXiByvtBQpc6cUWrjRsPhB6m9Chc2fWaZevWUWrVKqePHlSpdOun2ihWVunUruz8NYYyffkr6t1VKu4vx009KOToabA+FXH9dS1egi4uLU1u3blWvvvqqsrOzM7g1+dJLL6lffvlFPXjwwKBMVgc6pbQB4+XLl1d2dnaqYcOGan+C2S8GDhyoWrZsaZB/3759qkGDBsrOzk5VqFBBBoyL3OXxY6XatUs7aK1dq+X9v/9LclFL9jVwoFJPn/53nNu3lapTJ2m+KlW0QfoiZ+vXz/DvNmSI4fbr15V67z39rEN5LtD9+++/6rPPPlOlS5c2CG7ly5dXn332mbp48WKKZbMj0GU1CXQi20VHa3NkphS0Xn3VMP+dO9qFLrlZY2xstAHvyc3N+eCBUnXrJi1TpozW6hM5V/Xqhn+zOXOSz3fnjlLjxqlQR8dcf10zacC4lZUVOp1O/9ytd+/eDBgwgJYtW6ZZNiIiAmdnZ3Q6XZJu35bCEgZWCgtx8CCMHAlnzvyX5uKi9bAsVSpp/ps3tVUhnjyBp0+1Zzjt2xv0xkwiKAhat9b2mZCDA8yaBWXLamsFRkVBzZpQvz4kGsIjslhYmPY9SOjYMUhl/GPY9eu4VKqUq69r6Qp0zZo1448//qBcuXJGH0gCnRBZLCYG5s7VXra28Ouv0KKFeY8RGKh1Rrl0ybj8pUvDuHHaK40hOCIT7Nun/TiJZ2urDV+xt0+xiCVc10z6ptnZ2aGU4tChQ1StWpUePXqwevVqg9lBhBA5hI0NfPCB1uI6fdr8QQ6gRAnw8dEPLk7T3bvw0UfaIrgW+oM3R0s0qwx166Ya5CyFSYEuMDCQWbNm4ebmxvPnz9myZQtvvvkmrq6uvPPOO+zfvz+z6imEyKmKFdMWmh0xwvgyS5bAgAEpDloWGRAbqw0n2b1bGx6QUOJA5+6edfXKRiYFuoIFCzJq1ChOnTrFyZMnef/993FxcSEsLIzFixfTpk0bKlSowOeff55kXkQhhAWztYXZs2HRIm2yaYCiRbULaZMmkGiGG0CbZqpPn6QXY0uRHecVEACentpUcO3aac9YV678b9xcHg10GR5HFxkZqf744w/VunVrfU/M+PF08UMNgoKCpNelEHlFTIxSERFJ09auTX6h3O7dk67cntuNGaMt+lunjlLbt2fNMf38tIWBk+tt26CBUtu2JU0/eTLN3VrCdS3Dy/QkdP36dby8vFi2bBl37twBtDnWbGxsaNWqFd7e3tIZRYi8bNcubfaZxBMFd+kCa9dqPTZzu7//1nqsJjRhAnz5pfbcNC3h4fDPP9rsNu3ba89BQWshzpwJq1fDo0fa/KfPn4OdnTZbzs2bWo9ZY9nZacdKNP9tYpZwXTNroIunlGLnzp0sWrSIzZs38/z5c/2wBAl0QuRx+/dD164QEWGY3rEjrF8PuX0S4dGj4ZdfkqY3bqzdqm3SBNzctCWeQAv6Pj7amoX798OpU/911MmXDyZP1n4cDBigDQUwl5deMmp/lnBdy5RAl9DDhw9ZtmwZS5Ys4fz58xLohBBw6JC2SG3i+TTbtIFNm7QWSkZ5e2vd6Tt1ypwepympXTvp2MLkODpqHXnu30+6GkVGNWumrT7w1VeQUn+J99+HOXPS3JUlXNcyfSBL0aJFGT9+PGfPnuXw4cMMHTo0sw8phMjpmjXTbmMmXudwzx4tMIWFaR0rfHy0Qe+m/jj+7jvo0AG++UYb+pBowdVMExhoXJADrSV365b5g1z//lqPy3794OxZmDIl+cm/80pHFLKgRZeXWMIvHyGy1LFjWkBKvGCtra3hSu4FCmirKrRtq60RGD+7x9GjMHEi3L6trebwySdaL8MxY5Iea8IELfClsiZlhq1YoQWYePnza71Pb9wwbT82NlpwT+7yXLWq9rzP2VnLFx2t3QZ+9kxbgaJZs6TnGB/44tcEdXGBy5ehePE0q2IJ1zUJdGZkCV8IIbLcqVNap4tkVqJPlqur1kILCIBJkwzH4uXLl3qHjMGD4euvtRXZM8OwYeDl9d/7bt1g1SqtA8nBg1pgPn/ecJkc0GaJadJEGxLQurX2/+fPa9O4HT/+X76339ZuNyZuCRsjMFB7dvjvv9p+jRzkbwnXNQl0ZmQJXwghssXZs9pFPigo849lbQ09emidX5ydteeBtWtrraGMqljRsPX2008wdqxhnogILUg/eKCdr709NG363/jDhOLitN6o//yjtXw7dcp4HU1kCdc1CXRmZAlfCCGyzcWL2sX89u3/0uztM/YM67XXYN26pC2oxHQ6mD4dPv00/ce6dg0qVzZMO3NGm2YrF7OE65rMqiqEyBlq1NBu161dq62gfv26dhvy3j3t9l+XLsmX0+m0W5+JJ4n+v//TbhmuWZP2fI5Kac/wfvwx/fXfs8fwfbFiWktRZDsJdEKInMPZGV59VQtqFSpowatkSXjjDS34bdqk3R6MV6qUFmB27dKC5PDh2hCF336DqVO1PK+8An5+2vOz5KYiS+ijj7SpzNJj927D923ayAoNOYTcujQjS2jiC5HjPXumBb2wMOjdO+n6aqkJDYXly7VJjx8+1MbxnTuXNF/fvlovxfbttR6gaVFKm8Ek4TPG+fPh3XeNr1sOZQnXNQl0ZmQJXwgh8pwff9Racsmxt9emJbOx0YYKNGwIHh5aF34Pj/+68Z87l/RZ3L//Jn1mlwtZwnXNiInXhBDCgn34IURGwuefJ90WFfVfZ5jgYG0+yfXrtfceHlpHF1dX+OILw3LlykGlSplabWE8CXRCCDFpknaL8vPPDQeqp+aff6BlS+jeXetAk1Dnzpk7MF2YRG5dmpElNPGFyNMCA7WemitWwJEj6dtHwYLg66t1prEAlnBdk0BnRpbwhRBCvHDvnjYXZWys1sq7eVNrxW3erG1LjpUVbNumDUa3EJZwXZNAZ0aW8IUQQqTh3j1t6MClS0m3ffttxgad50CWcF2TQR5CCGGKUqW0dePq1DFMf+MNbVJpkeNYZKB7/Pgx/fv3x8XFBRcXF/r3709ISEiqZdatW0fHjh0pWrQoOp0OPz+/LKmrECIXcnWFvXvh9de1GVAGDYLFi6UDSg5lkYGub9+++Pn5sWPHDnbs2IGfnx/9+/dPtUxERATNmjXj22+/zaJaCiFytaJF4a+/tEHiS5aYZ7FYkSksbnjBhQsX2LFjB0eOHKFJkyYALFy4EA8PDy5dukT16tWTLRcfCG+Yum6UEEKIHM3iWnT//PMPLi4u+iAH0LRpU1xcXDh8+LBZjxUVFUVYWJjBSwghRM5icYEuMDCQ4smsmlu8eHECAwPNeqzp06frnwO6uLhQtmxZs+5fCCFExuWaQPfFF1+g0+lSfZ04cQIAXTIPhJVSyaZnxMSJEwkNDdW/bidcR0sIIUSOkGue0Y0aNYo333wz1TwVKlTgzJkz3L9/P8m2Bw8e4OrqatY62dvbY5/WOldCCCGyVa4JdEWLFqVo0aJp5vPw8CA0NJRjx47RuHFjAI4ePUpoaCienp6ZXU0hhBA5TK65dWmsmjVr0qlTJ9555x2OHDnCkSNHeOedd+jWrZtBj8saNWqwPn4WcuDRo0f4+fnh7+8PwKVLl/Dz8zP7cz0hhBBZy+ICHcDy5cupW7cuHTp0oEOHDtSrV4/ff//dIM+lS5cIDQ3Vv9+0aRMNGjSga9euALz55ps0aNCAefPmZWndhRBCmJfMdWlGoaGhFCxYkNu3b+faOeGEECKhsLAwypYtS0hICC6mrOaeg+SaZ3S5QXBwMIAMMxBCWJzg4GAJdAIKFy4MwK1bt3LtFyI94n/x5bWWrJy3nHdeEBoaSrly5fTXt9xIAp0ZWVlpjzxdXFzy1D+EeAUKFJDzzkPkvPOW+OtbbpR7ay6EEEIYQQKdEEIIiyaBzozs7e2ZMmVKnpstRc5bzjsvkPPOvectwwuEEEJYNGnRCSGEsGgS6IQQQlg0CXRCCCEsmgQ6IYQQFk0CnYnmzJlDxYoVcXBwoFGjRvj4+KSaf//+/TRq1AgHBwcqVaqUayeJNuW8161bR/v27SlWrBgFChTAw8ODnTt3ZmFtzcfUv3e8Q4cOYWNjQ/369TO3gpnE1POOiopi0qRJlC9fHnt7eypXrszixYuzqLbmY+p5L1++HDc3N/Lly0fJkiUZPHiwfirA3ODAgQN0796dUqVKodPp2LBhQ5plcuU1TQmjrVy5Utna2qqFCxcqf39/NWbMGOXk5KRu3ryZbP5r166pfPnyqTFjxih/f3+1cOFCZWtrq9asWZPFNc8YU897zJgx6rvvvlPHjh1Tly9fVhMnTlS2trbq1KlTWVzzjDH1vOOFhISoSpUqqQ4dOig3N7esqawZpee8e/TooZo0aaK8vb3V9evX1dGjR9WhQ4eysNYZZ+p5+/j4KCsrK/Xzzz+ra9euKR8fH1W7dm3Vq1evLK55+m3btk1NmjRJrV27VgFq/fr1qebPrdc0CXQmaNy4sRo+fLhBWo0aNdSECROSzf/JJ5+oGjVqGKS99957qmnTpplWx8xg6nknp1atWmrq1KnmrlqmSu959+nTR33++edqypQpuTLQmXre27dvVy4uLio4ODgrqpdpTD3vH374QVWqVMkgbdasWapMmTKZVsfMZEygy63XNLl1aaTo6GhOnjxJhw4dDNI7dOjA4cOHky3zzz//JMnfsWNHTpw4wfPnzzOtruaUnvNOLC4ujvDw8Fw1KWx6z3vJkiVcvXqVKVOmZHYVM0V6znvTpk24u7vz/fffU7p0aapVq8ZHH33Es2fPsqLKZpGe8/b09OTOnTts27YNpRT3799nzZo1+jUtLVFuvabJpM5GevjwIbGxsbi6uhqku7q6prgKeWBgYLL5Y2JiePjwISVLlsy0+ppLes47sR9//JGIiAjeeOONzKhipkjPeV+5coUJEybg4+ODjU3u/KeVnvO+du0aBw8exMHBgfXr1/Pw4UNGjBjBo0ePcs1zuvSct6enJ8uXL6dPnz5ERkYSExNDjx49+OWXX7Kiytkit17TpEVnIp1OZ/BeKZUkLa38yaXndKaed7w///yTL774glWrVlG8ePHMql6mMfa8Y2Nj6du3L1OnTqVatWpZVb1MY8rfOy4uDp1Ox/Lly2ncuDFdunRhxowZLF26NFe16sC08/b392f06NFMnjyZkydPsmPHDq5fv87w4cOzoqrZJjde03Lnz85sULRoUaytrZP8ugsKCkryCydeiRIlks1vY2NDkSJFMq2u5pSe8463atUqhg4dyurVq2nXrl1mVtPsTD3v8PBwTpw4ga+vL6NGjQK0AKCUwsbGhl27dtGmTZssqXtGpOfvXbJkSUqXLm2wBmPNmjVRSnHnzh2qVq2aqXU2h/Sc9/Tp02nWrBkff/wxAPXq1cPJyYkWLVrw1Vdf5djWTUbk1muatOiMZGdnR6NGjfD29jZI9/b2xtPTM9kyHh4eSfLv2rULd3d3bG1tM62u5pSe8watJTdo0CBWrFiRK59ZmHreBQoU4OzZs/j5+elfw4cPp3r16vj5+dGkSZOsqnqGpOfv3axZM+7du8eTJ0/0aZcvX8bKyooyZcpkan3NJT3n/fTp0yRrtFlbWwP/tXIsTa69pmVTJ5hcKb77sZeXl/L391djx45VTk5O6saNG0oppSZMmKD69++vzx/fFXfcuHHK399feXl55YquuImZet4rVqxQNjY2avbs2SogIED/CgkJya5TSBdTzzux3Nrr0tTzDg8PV2XKlFGvvfaaOn/+vNq/f7+qWrWqGjZsWHadQrqYet5LlixRNjY2as6cOerq1avq4MGDyt3dXTVu3Di7TsFk4eHhytfXV/n6+ipAzZgxQ/n6+uqHVFjKNU0CnYlmz56typcvr+zs7FTDhg3V/v379dsGDhyoWrZsaZB/3759qkGDBsrOzk5VqFBBzZ07N4trbB6mnHfLli0VkOQ1cODArK94Bpn6904otwY6pUw/7wsXLqh27dopR0dHVaZMGTV+/Hj19OnTLK51xpl63rNmzVK1atVSjo6OqmTJkqpfv37qzp07WVzr9Nu7d2+q/1Yt5Zomy/QIIYSwaPKMTgghhEWTQCeEEMKiSaATQghh0STQCSGEsGgS6IQQQlg0CXRCCCEsmgQ6IYQQFk0CnRBCCIsmgU4IIYRFk0AnhLBogwYNQqfTMWjQoOyuisgmEuhEqiIjI5k/fz7du3enXLlyODo64uLiQs2aNXnvvfc4cOBAdlcxV6pfvz46nY7du3cblf+LL75Ap9MleTk4OFCmTBl69OjBX3/9leys+QnLJpTc/ox9LV26NNX6vvPOO+h0OooUKUJUVJTRn0uVKlXQ6XT06NHD6DJCpEXWoxMp8vb2ZsiQIdy5c0efVqBAAaKiorh48SIXL15kwYIFdO/end9++41ChQplY21zj5s3b3L69GkKFizIyy+/bHL5hOujhYaGcvfuXe7evcvmzZtZunQp69evx97e3qT9JPTkyRMiIiJSzePo6JjqvocOHcqiRYt49OgRGzduNGp1+f3793P16lV9eSHMRVp0Ill//fUXXbp04c6dO5QuXVp/0QoNDSUyMpILFy4wduxYbGxs2Lx5M56engQHB2d3tXOFjRs3AtClS5d0reEVGBiof0VERHDu3Dnat28PwPbt2/n8889N3k/C10cffZRmnj59+qS676ZNm1KrVi0AlixZYlR94vO5urrmyjUMRc4lgU4kcfHiRYYMGUJMTAx169bF19eXoUOHGrTYatSowU8//cTGjRuxs7Pj4sWLDBw4MBtrnXvEB7qePXtmeF9WVlbUrl2bTZs2UaVKFQDmz59PTExMhvedUfGtsl27dhncFUhOeHg4a9asAWDAgAHY2MjNJmE+EuhEEpMmTSIiIgJ7e3tWr15NsWLFUszbpUsXfQti69at/P3331lVzVzp8ePHHDhwADs7Ozp16mS2/To4OPD6668DWtC4ePGi2fadXv3798fW1pa4uDh+++23VPOuWrVKf7t0yJAhBttCQ0NZuXIl/fr1o27duhQuXBgHBwfKly9P3759OXLkSLrqV6FChTSfNxrTkSUwMJAJEybg5uaGi4sLDg4OVKpUiWHDhuHv75+uugnzkkAnDAQEBLBhwwYA3nrrLapXr55mmXHjxuHs7AzAr7/+mpnVy/W2bt1KTEwMbdq0oUCBAmbdd5kyZfT/HxYWZtZ9p0exYsX0nUrS6rwSf9uyWbNm1KhRw2DbTz/9xFtvvcWKFSs4d+4cz58/B+DWrVv8+eefeHp6MmvWLPOfgBG2bNlC1apV+e677zhz5gzPnj3DxsaG69ev4+XlRYMGDVi2bFm21E38RwKdMLBv3z7i4uIA6N27t1Fl8ufPT4cOHQCtQ0F8eZGUOW9bJnbjxg39/xcuXNjs+0+P+NuX//77b4o9dC9dusThw4eBpK05gBIlSjBu3DiOHDnC48ePCQ8P59mzZ1y7do0xY8YAMH78eHx9fTPpLJJ37NgxevfuzZMnT3jvvfe4cOECz54948mTJ9y8eZMRI0YQHR3N0KFDOXHiRJbWTRiSQCcMnD9/Xv//DRo0MLpc/fr1AQgJCeHWrVvmrpZFiIqKYseOHZnSfT4sLIzly5cDWpCrVq2aWfefXh07dtS3NBcvXpxsnvj0/PnzJ9s7c/jw4cyYMYMmTZpQsGBBQBsaUbFiRWbOnMmIESOIjY1l9uzZmXMSKRg1ahTR0dH83//9H/PmzaNGjRpYW1sDUK5cOWbPns3o0aOJiYnhq6++ytK6CUMS6ISBhD0nixQpYnS5okWLJruPtJQpU4ZevXoZnT8327NnD0+ePMHd3Z1SpUqZZZ8hISHs3r2bNm3acO/ePQDGjBmDlVXO+KdtZWWl76S0Zs0anjx5YrA9NjaW33//HYA+ffqQP39+k48R30Pz4MGDGayt8U6fPs3x48extbXlww8/TDHfgAEDAPj777+JjY3NquqJRKRrkzCLhAOVEw8Q/uWXXyhYsCD9+/c3SA8ODubu3bsMHjw4S+qY3eKffWb0tmXigd8Jvf3220yaNClD+ze3IUOG8M033xAREcGqVasMxsht376dgIAAfb6UXLt2jTlz5rB3716uXr1KeHh4klvkafXsNKf4oBoXF5fqc+z44BYREUFwcDDFixfPkvoJQxLohIGErbjg4GBKly5tVLmErbiEwxAiIyP58MMPef/995MEOj8/PwDq1q2bgRrnDkopNm/eDJDhFmzCQdz29vYULVqUBg0a0K9fP1q3bp2hfWeGSpUq0apVK/bu3cvixYsNAl38bcsaNWrg6emZbPn169fz1ltvGfyAKlCgAA4ODuh0OqKjo3n8+LG+12ZWiG89x8bGcv/+faPKPH36NDOrJFIhgU4YiB/kC3Dq1CmjA118RwAbGxsqVapkkP78+XMaN26cpMzp06cBqFevXkaqbHbPnz/HxsYm1ZaTqY4dO0ZAQACVK1emdu3aGdpXYGCgmWqVdYYOHcrevXs5fPgwly5donr16jx8+JAtW7botycnODiYQYMGERUVRZs2bZg8eTKNGzc2mJll9+7dtGvXLkvOI158S61GjRpcuHAhS48tTJczbuSLHKN169b65ztr1641qsyTJ0/w9vYGwMPDQz/9VKdOnfS/0t9++239PInxLRs/Pz/s7e1xdnbmvffeo2TJkjg7O9O1a1f97ayELl68yIABAyhVqhSOjo7Uq1cvxfFZvr6+vP766xQvXhwHBwfc3d3Ztm1bknxDhw4lX758XL16lb59+1KkSBGcnZ15++23sbW15dmzZ0nKLFmyBJ1OZ9KYwczsbZkb9O7dW9+RJH4owe+//67/UZG4tR9v27ZthIWFUahQITZv3kzLli2TTD+W3sAfPyg9MjIyxTyhoaHJppcoUQLQbqlmZUtSpI8EOmGgZMmS+ltrK1eu5NKlS2mW+emnnwgPDwcwmB1l5MiRtGrVCltbW37//Xf9q3nz5oDWoitUqBDNmjUjLi6OL774gv79+7Nt2zbGjx9vcIy///6bhg0b4uvry5gxY5gxYwalSpVi0KBBScYprV69miZNmnD9+nU+++wzfvj/9u41pMnojwP41zYv0+ZMKxuUOhVziaAWNJkQliFZIzKxMswuklT2ohdmUJgUkTGIMoO9UUOxMAlJUelG96BC1C6WlyDaKMzLspRS537/F7GHzW361/r/rfX7wF4855zfec4u+tuz53nO0WoxPj4OjUZjN4lya2srpFIp1Go1xGIxTp06Ba1WC5VKBZPJZHfJ+vDwMI4dO4b169dP6yjid52f+1t5eXkhIyMDAFBRUYHx8XEh4W3YsMHpnJp6vR4AsHTpUnh7eztsM9NJCiw/sVv2MZHZbHZ6W4BarQYAjI6Oora2dkb7Z/9HxNgEr1+/JolEQgAoOjqaent7nbZtbGwkDw8PAkCRkZE0OjpqU5+QkEAxMTF2cSMjI+Tu7k4ikYju3LljFxMaGipsGwwGkslklJ6eTiaTSSg3m80UHx9v0/+rV6/Iw8ODUlNTaWxsTCgfGBggX19fSkpKEsrGxsbI09OTAFBNTY3NGJ4+fUoA6Pz58zblBQUFJBaLqb293elrMlFXVxcBoPnz59uMfzqOHz9OAGgmf7LTjf2VfU2mublZ6Nd6H/X19U5jSkpKCAD5+/vT9+/f7epbWlqEz5+z8WZlZREAysrKsinfs2cPASClUklms9kurqysTOh3YqzZbKbY2FgCQEFBQfT58+dJn3t/f/+k9ex/ixMdc6iqqopEIhEBoMWLF1NpaSkZjUahvqOjgw4dOkRisZgAkEwmo9bWVps+zGYzSaVS2rVrl13/LS0tBID27dtnV7dmzRqKiooStvfu3UtSqZS6u7upt7fX5pGTk0M+Pj5C223btpGnpyf19PTY9atWqykoKEjYfvHiBQGgrVu32rUdGRkhT09PyszMFMoMBgN5e3vT/v37nbxqjmm1WgJAO3funFacNVdIdEREMTExBIDmzJlDAEgul0+a/Ds7O4W2qampZDAYiOjn+1NdXU0LFiyggICAGSW627dvC3HZ2dnU19dHRESDg4N09uxZ8vDwIH9/f4exRD+/DFm+KCkUCqqpqaHh4WGh3mAwUGVlJSUlJVF2dvY0Xyn2O3GiY041NjaSXC4X/hlYEpqXl5dNWWhoKDU3N9vFW45kiouL7eouXbpEAOju3bt2dXK5nDZv3kxERCaTiebNm2ezv4kPuVxORD+P0Hx8fITYiRISEkipVArbFRUVBIDq6uoctlepVBQZGSls79ixg3x9faf89u5ovwCotrZ2WnHWXCXRXbhwwea9O3LkyJQx+fn5dp9Bd3d3IcFUVVXNKNER/XxPrfv28/MTEmtubu6ksUREN2/etEm0IpGIAgICyNvb26ZfTnSzi6+6ZE6tW7cO7969Q3l5ORoaGtDW1oa+vj6by7wzMzOh0+kcnj+xnN9yNMNKa2sr3NzcsGLFCpvynp4efPr0SYjR6/UwGo04cOCA08vyLXNGWi4MUCqVdm3MZjPevHljc17NMgZna8KpVCoUFxfj27dv6OrqQmVlJU6fPj3pJNcT9fb24smTJ5BIJMI0af+y7du3Iy8vT7gAZLJ75yyKiooQFRWFkpISvHz5EmNjYwgPD8emTZtw+PDhX5r6q6ysDMuXL0d5eTk6OjpgNpuhVquRm5uL9PT0KVclX7t2Lbq7u6HT6dDQ0ID29nZ8+fIFEokEy5YtQ3x8PDZu3Cgso8RmyWxnWvb3MZlMpNFohG/Xjo7miIiOHj1Kbm5u9PXrV7u6xMREioiIsCtvamoiANTQ0EBERG1tbQSAtFrtlOPq7OwkAHTy5Em7uuvXrxMAunz5slC2evVqCgsLc9rflStXCADdu3ePVq1aRcHBwfTjx48px2GttLSUAJBGo5lWHGPs9+GrLtm0iUQiVFdXIz4+HoODg0hOTna4HMn79+/h5+cnrGxgra2tTZgf09rEo8Dg4GCIxWJcu3bN4WTR1jfrKhQKSCQSu6mgPn78iIMHD0KpVCItLc1mDJPN56lSqQAABQUFuH//PoqKiv6rlbutWW4r+FemOWPsT8Q/XbIZkUgkqK+vR0JCAt6+fYukpCQ8fPgQYWFhQpuQkBAYjUbk5+cjOjoaMpkMGo0Ger0eAwMDDpNMS0sLAgMDIZfLAQAymQw5OTm4ePEiVCoVtmzZAqlUig8fPuDRo0cIDAxEdXU1gJ/3ReXl5eHEiRPIyMhAYmIiDAYDdDodRCIR6urqhBW99Xo9+vv7ERcX5/Q5hoSEYOHChXjw4AFWrlw55arajqjVasTGxv6ztxUw9keY7UNK5rqMRiOlpaUJF5OkpKQQEVF9fT0BoKamJruY8PBwSk5OtikzmUyk0+koLi6OfH19ae7cuRQREUG7d++mZ8+e2bUtLCykJUuWkLu7OwUHB1Nubq7dLRKTjcFaSkoKAaDHjx/P5CVgjP0B3IisZuNljAmGhoagUCiQmJiIq1evzvZwGGMzxOfoGHOisLAQQ0NDOHPmzGwPhTH2C/gcHWNWBgYGcOPGDTx//hznzp2DVquFQqGY7WExxn4BJzrGrNy6dQsZGRlYtGgRCgoKJl1UkzH2d+BzdIwxxlwan6NjjDHm0jjRMcYYc2mc6BhjjLk0TnSMMcZcGic6xhhjLo0THWOMMZfGiY4xxphL40THGGPMpXGiY4wx5tI40THGGHNpnOgYY4y5NE50jDHGXNp/AN07H+w2fGsKAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 400x500 with 3 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
     "from matplotlib import gridspec\n",
@@ -799,33 +582,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "id": "49bb4cfe-af95-45f1-91f1-ed9c08009f82",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'yvals': array([[3.89700344e-02, 4.19601453e-02, 4.51285204e-02, ...,\n",
-       "         2.62053991e-05, 2.25728506e-05, 1.94218223e-05],\n",
-       "        [3.89700344e-02, 4.19601453e-02, 4.51285204e-02, ...,\n",
-       "         2.62053991e-05, 2.25728506e-05, 1.94218223e-05],\n",
-       "        [4.14258100e-02, 4.44458326e-02, 4.76352519e-02, ...,\n",
-       "         5.07430591e-05, 4.41358503e-05, 3.83480852e-05],\n",
-       "        ...,\n",
-       "        [3.88002224e-02, 4.17888388e-02, 4.49564409e-02, ...,\n",
-       "         2.48184959e-05, 2.13613429e-05, 1.83648215e-05],\n",
-       "        [4.00282984e-02, 4.30368549e-02, 4.62204005e-02, ...,\n",
-       "         3.40303269e-05, 2.94265929e-05, 2.54175329e-05],\n",
-       "        [3.91841442e-02, 4.22347601e-02, 4.54700312e-02, ...,\n",
-       "         1.84646055e-05, 1.58307403e-05, 1.35568366e-05]])}"
-      ]
-     },
-     "execution_count": 37,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "res.objdata()"
    ]
@@ -841,9 +601,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:.conda-ddrailnv]",
+   "display_name": "Python [conda env:.conda-ddr]",
    "language": "python",
-   "name": "conda-env-.conda-ddrailnv-py"
+   "name": "conda-env-.conda-ddr-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -36,8 +36,8 @@ class DeepDiscInformer(CatInformer):
     config_options.update(
         cfgfile=Param(str, None, required=True, msg="The primary configuration file for the deepdisc models."),
         batch_size=Param(int, 1, required=False, msg="Batch size of data to load."),
-        numclasses=Param(int, 1, required=False, msg="The number of classes in the model."),
-        epochs=Param(int, 20, required=False, msg="How many epochs to train for."),
+        numclasses=Param(int, 1, required=False, msg="The number of classes to predict."),
+        epochs=Param(int, 20, required=False, msg="Number of epochs to train for."),
         output_dir=Param(str, "./", required=False, msg="The directory to write output to."),
         output_name=Param(str, "deepdisc_informer", required=False, msg="Name of the saved model."),
         chunk_size=Param(int, 100, required=False, msg=""), # TODO we define this in deep_dict in the notebook, but we don't use it - is this an option we want to add?
@@ -154,19 +154,16 @@ class DeepDiscEstimator(CatEstimator):
 
     name = "DeepDiscEstimator"
     config_options = CatEstimator.config_options.copy()
-    """
     config_options.update(
         cfgfile=Param(str, None, required=True, msg="The primary configuration file for the deepdisc models."),
         batch_size=Param(int, 1, required=False, msg="Batch size of data to load."),
         numclasses=Param(int, 1, required=False, msg="The number of classes in the model."),
         epochs=Param(int, 20, required=False, msg="How many epochs to run estimation."),
-        output_dir=Param(str, "./", required=False, msg="The directory to write output to."),
-        output_name=Param(str, "deepdisc_estimator", required=False, msg="Name of the saved model."),
+        output_dir=Param(str, "./", required=False, msg=""),
+        output_name=Param(str, "deepdisc_estimator", required=False, msg=""),
         chunk_size=Param(int, 100, required=False, msg=""), # TODO (same question as above)
     )
-    """
-    # TODO: what was the verdict on including hdf5_groupname as an input param?
-
+    # TODO : same hdf5_groupname question
     outputs = [("output", TableHandle)]
 
     def __init__(self, args, comm=None):
@@ -234,8 +231,8 @@ class DeepDiscPDFEstimator(CatEstimator):
         batch_size=Param(int, 1, required=False, msg="Batch size of data to load."),
         numclasses=Param(int, 1, required=False, msg="The number of classes in the model."),
         epochs=Param(int, 20, required=False, msg="How many epochs to run estimation."),
-        output_dir=Param(str, "./", required=False, msg="The directory to write output to."),
-        output_name=Param(str, "deepdisc_estimator", required=False, msg="Name of the saved model."),
+        output_dir=Param(str, "./", required=False, msg=""),
+        output_name=Param(str, "deepdisc_pdf_estimator", required=False, msg=""),
         chunk_size=Param(int, 100, required=False, msg=""), # TODO (same question as above)
     )
     # config_options.update(hdf5_groupname=SHARED_PARAMS) 

--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -4,6 +4,7 @@ import detectron2.data as d2data
 import detectron2.solver as solver
 import numpy as np
 import qp
+from ceci.config import StageParameter as Param
 from deepdisc.data_format.augment_image import train_augs
 from deepdisc.data_format.image_readers import DC2ImageReader
 # from deepdisc.data_format.register_data import (register_data_set,
@@ -32,9 +33,17 @@ class DeepDiscInformer(CatInformer):
 
     name = "DeepDiscInformer"
     config_options = CatInformer.config_options.copy()
-    # Add defaults and a help message
-    # e.g. cfgfile = Param(str, None, required=True,
-    #        msg="The primary configuration file for the deepdisc models."),
+    config_options.update(
+        cfgfile=Param(str, None, required=True, msg="The primary configuration file for the deepdisc models."),
+        batch_size=Param(int, 1, required=False, msg="Batch size of data to load."),
+        numclasses=Param(int, 1, required=False, msg="The number of classes in the model."),
+        epochs=Param(int, 20, required=False, msg="How many epochs to train for."),
+        output_dir=Param(str, "./", required=False, msg="The directory to write output to."),
+        output_name=Param(str, "deepdisc_informer", required=False, msg="Name of the saved model."),
+        chunk_size=Param(int, 100, required=False, msg=""), # TODO we define this in deep_dict in the notebook, but we don't use it - is this an option we want to add?
+    )
+    # TODO: what was the verdict on including hdf5_groupname as an input param?
+        
     
     inputs = [('input', TableHandle), ('metadata', JsonHandle)]
     #outputs = [('model', ModelHandle)]
@@ -145,7 +154,18 @@ class DeepDiscEstimator(CatEstimator):
 
     name = "DeepDiscEstimator"
     config_options = CatEstimator.config_options.copy()
-    config_options.update()
+    """
+    config_options.update(
+        cfgfile=Param(str, None, required=True, msg="The primary configuration file for the deepdisc models."),
+        batch_size=Param(int, 1, required=False, msg="Batch size of data to load."),
+        numclasses=Param(int, 1, required=False, msg="The number of classes in the model."),
+        epochs=Param(int, 20, required=False, msg="How many epochs to run estimation."),
+        output_dir=Param(str, "./", required=False, msg="The directory to write output to."),
+        output_name=Param(str, "deepdisc_estimator", required=False, msg="Name of the saved model."),
+        chunk_size=Param(int, 100, required=False, msg=""), # TODO (same question as above)
+    )
+    """
+    # TODO: what was the verdict on including hdf5_groupname as an input param?
 
     outputs = [("output", TableHandle)]
 
@@ -205,13 +225,22 @@ class DeepDiscPDFEstimator(CatEstimator):
     """DeepDISC estimator"""
 
     name = "DeepDiscPDFEstimator"
-    config_options = CatInformer.config_options.copy()
     inputs = [('input', TableHandle), ('metadata', JsonHandle)]
     outputs =[('output', QPHandle), ('truth',TableHandle)]
 
-    #config_options.update()
-    # config_options.update(hdf5_groupname=SHARED_PARAMS)
-
+    config_options = CatInformer.config_options.copy()
+    config_options.update(
+        cfgfile=Param(str, None, required=True, msg="The primary configuration file for the deepdisc models."),
+        batch_size=Param(int, 1, required=False, msg="Batch size of data to load."),
+        numclasses=Param(int, 1, required=False, msg="The number of classes in the model."),
+        epochs=Param(int, 20, required=False, msg="How many epochs to run estimation."),
+        output_dir=Param(str, "./", required=False, msg="The directory to write output to."),
+        output_name=Param(str, "deepdisc_estimator", required=False, msg="Name of the saved model."),
+        chunk_size=Param(int, 100, required=False, msg=""), # TODO (same question as above)
+    )
+    # config_options.update(hdf5_groupname=SHARED_PARAMS) 
+    # TODO : same hdf5_groupname question
+    
     def __init__(self, args, comm=None):
         """Constructor:
         Do Estimator specific initialization"""


### PR DESCRIPTION
For lincc-frameworks/deepdisc#75

I have to step out for an hour or two, so I wanted to go ahead and ask for some feedback on the descriptions given in the Params while I can (and on whether any should be set `required=True`--I'm assuming the default values will cover these, but perhaps some should be explicitly set by the user).

I'm especially unsure about `output_dir` and `output_name` in the estimator stages--it looks like these might be for finding the saved checkpoints? Should they be named to reflect that?

Inputs to add still:
- eval_period
- NUM_EPICS_BETWEEN_EPOCHS=5
- NUM_LSST_FILTERS=6 


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
