### PR TITLE
Fixing height/width ordering for reshape.

### DIFF
--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -67,11 +67,10 @@ class DeepDiscInformer(CatInformer):
         for start_idx, _, chunk in itr:
             for idx, image in enumerate(chunk['images']):
                 this_img_metadata = metadata[start_idx + idx]
-                height = this_img_metadata["height"]
-                width = this_img_metadata["width"]
+                image_height = this_img_metadata["height"]
+                image_width = this_img_metadata["width"]
 
-                #! This spot could have bugs width, height, or height, width???
-                reformed_image = image.reshape(6, width, height).astype(np.float32)
+                reformed_image = image.reshape(6, image_height, image_width).astype(np.float32)
 
                 filename = f'image_{start_idx + idx}.npy'
                 file_path = os.path.join(self.temp_dir, filename)
@@ -243,11 +242,10 @@ class DeepDiscPDFEstimator(CatEstimator):
         for start_idx, _, chunk in itr:
             for idx, image in enumerate(chunk['images']):
                 this_img_metadata = metadata[start_idx + idx]
-                height = this_img_metadata["height"]
-                width = this_img_metadata["width"]
+                image_height = this_img_metadata["height"]
+                image_width = this_img_metadata["width"]
 
-                # Note well: the predictor assumes a different image shape than the informer. 
-                reformed_image = image.reshape(6, width, height).astype(np.float32)
+                reformed_image = image.reshape(6, image_height, image_width).astype(np.float32)
 
                 filename = f'image_{start_idx + idx}.npy'
                 file_path = os.path.join(self.temp_dir, filename)


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
Addresses #22, updates the ordering of the height,width for reshaping flattened images.

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
