### PR TITLE
Code clean up and variable renaming

### DIFF
--- a/rail_wrap_test.ipynb
+++ b/rail_wrap_test.ipynb
@@ -245,6 +245,7 @@
     "    head_iters=20,\n",
     "    full_iters=20,\n",
     "    machine_rank=0,\n",
+    "    num_machines=0,\n",
     "    #     hdf5_groupname=\"images\",\n",
     ")"
    ]
@@ -984,9 +985,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:.conda-ddrailnv]",
+   "display_name": "rail_deepdisc39",
    "language": "python",
-   "name": "conda-env-.conda-ddrailnv-py"
+   "name": "rail_deepdisc39"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Apply the renaming work to the recent changes after moving `train` outside of the Informer class.

Rebasing became a bit of a nightmare, and there weren't that many changes in the previous renaming PR. I've simply applied those here, and I've done a little more clean up to remove unnecessary commented out code, etc. 

With this PR, we should close out PR #25 to avoid conflicts. 

## Problem & Solution Description (including issue #)
A good chunk of this work is just duplicating what @doug did in the renaming PR #25. 

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
