### PR TITLE
Introduce training/evaluation split for input data.

### DIFF
--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -132,14 +132,12 @@ def train(config, all_metadata, train_head=True):
         cfg_loader.SOLVER.MAX_ITER = efinal  # for DefaultTrainer
 
         saveHook = return_savehook(output_name)
-        # lossHook = return_evallosshook(val_per, model, eval_loader)
+        lossHook = return_evallosshook(val_per, model, eval_loader)
         schedulerHook = return_schedulerhook(optimizer)
-        # removing the eval loss eval hook for testing as it slows down the training
-        # hookList = [lossHook, schedulerHook, saveHook]
-        hookList = [schedulerHook, saveHook]
+        hookList = [lossHook, schedulerHook, saveHook]
 
         trainer = return_lazy_trainer(
-            model, loader, optimizer, cfg, cfg_loader, hookList
+            model, training_loader, optimizer, cfg, cfg_loader, hookList
         )
 
         trainer.set_period(period)

--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -58,7 +58,7 @@ def train(config, all_metadata, train_head=True):
     # Create slices for the input data
     total_images = len(all_metadata)
     train_slice = slice( int(np.floor(total_images * config[training_percent])) )
-    eval_slice = slice( int(np.floor(total_images * config[training_percent])) + 1, total_images )
+    eval_slice = slice( int(np.floor(total_images * config[training_percent])), total_images )
 
     mapper = RedshiftDictMapper(
         DC2ImageReader(), lambda dataset_dict: dataset_dict["filename"]
@@ -70,7 +70,7 @@ def train(config, all_metadata, train_head=True):
 
     #! Grant to confirm these input variables
     eval_loader = d2data.build_detection_test_loader(
-        all_metadata[eval_slice], mapper=mapper, total_batch_size=batch_size
+        all_metadata[eval_slice], mapper=mapper, batch_size=batch_size
     )
 
     if train_head:
@@ -168,7 +168,7 @@ class DeepDiscInformer(CatInformer):
         output_dir=Param(str, "./", required=False, msg="The directory to write output to."),
         output_name=Param(str, "deepdisc_informer", required=False, msg="What to call the generated output."),
         chunk_size=Param(int, 100, required=False, msg="Chunk size used within detectron2 code."),
-        training_percent=Param(float, 0.8, required=False, msg="The percentage of the input data to use for training. The remaining percent is used for evaluation."),
+        training_percent=Param(float, 0.8, required=False, msg="The fraction of input data used to split into training/evaluation sets"),
     )
     inputs = [('input', TableHandle), ('metadata', JsonHandle)]
 

--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -68,7 +68,6 @@ def train(config, all_metadata, train_head=True):
         all_metadata[train_slice], mapper=mapper, total_batch_size=batch_size
     )
 
-    #! Grant to confirm these input variables
     eval_loader = d2data.build_detection_test_loader(
         all_metadata[eval_slice], mapper=mapper, batch_size=batch_size
     )


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
This addresses issue #34. The goal is to allow the user to prove a single input data file and metadata file. We'll cache the image data as before and create slices on the metadata (based on the provided `training_percentage` stage config) so that we can create two loaders, one for training and one for evaluation.

 The default training_percentage value is set to 0.8, but @grantmerz please confirm what value is best. 

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
