### PR TITLE
Use DataStore to manage model weights

### DIFF
--- a/rail_wrap_test.ipynb
+++ b/rail_wrap_test.ipynb
@@ -5,7 +5,16 @@
    "execution_count": 1,
    "id": "1c2a2dbf",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/drewoldag/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
    "source": [
     "# Training script for LazyConfig models\n",
     "try:\n",
@@ -80,7 +89,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Mon Dec 11 16:48:49 2023       \n",
+      "Tue Dec 19 00:02:47 2023       \n",
       "+---------------------------------------------------------------------------------------+\n",
       "| NVIDIA-SMI 545.23.08              Driver Version: 545.23.08    CUDA Version: 12.3     |\n",
       "|-----------------------------------------+----------------------+----------------------+\n",
@@ -89,11 +98,11 @@
       "|                                         |                      |               MIG M. |\n",
       "|=========================================+======================+======================|\n",
       "|   0  Tesla V100-SXM2-16GB           On  | 00000004:04:00.0 Off |                    0 |\n",
-      "| N/A   34C    P0              36W / 300W |      1MiB / 16384MiB |      0%      Default |\n",
+      "| N/A   32C    P0              38W / 300W |      0MiB / 16384MiB |      0%      Default |\n",
       "|                                         |                      |                  N/A |\n",
       "+-----------------------------------------+----------------------+----------------------+\n",
-      "|   1  Tesla V100-SXM2-16GB           On  | 00000035:04:00.0 Off |                    0 |\n",
-      "| N/A   38C    P0              40W / 300W |      1MiB / 16384MiB |      0%      Default |\n",
+      "|   1  Tesla V100-SXM2-16GB           On  | 00000035:03:00.0 Off |                    0 |\n",
+      "| N/A   29C    P0              37W / 300W |      0MiB / 16384MiB |      0%      Default |\n",
       "|                                         |                      |                  N/A |\n",
       "+-----------------------------------------+----------------------+----------------------+\n",
       "                                                                                         \n",
@@ -234,25 +243,28 @@
    "source": [
     "deep_dict = dict(\n",
     "    cfgfile=\"/home/shared/hsc/detectron2/configs/COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_1x.py\",\n",
+    "    num_gpus=1,\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "d611ae20-a7c7-4f52-9390-1d27eca138f0",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Inform = DeepDiscInformer.make_stage(name='Inform_DeepDISC', model='detectron2://ImageNetPretrained/MSRA/R-50.pkl', **deep_dict)\n",
     "Inform = DeepDiscInformer.make_stage(\n",
-    "    name=\"Inform_DeepDISC\", model=\"test_informer.pkl\", **deep_dict\n",
+    "    name=\"Inform_DeepDISC\", \n",
+    "    model=\"deepdisc_informer.pkl\", # Important that this has a name different than the .pth model weights file.\n",
+    "    **deep_dict\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "e4924105-cdc7-4d7d-a4a6-89fea0545313",
    "metadata": {},
    "outputs": [],
@@ -265,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "id": "87b6a9d1-697e-4bde-abee-e519253daa6f",
    "metadata": {},
    "outputs": [
@@ -275,95 +287,127 @@
      "text": [
       "Caching data\n",
       "Training head layers\n",
-      "\u001b[32m[12/11 16:50:30 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
-      "\u001b[32m[12/11 16:50:30 d2.data.common]: \u001b[0mSerializing 1000 elements to byte tensors and concatenating them all ...\n",
-      "\u001b[32m[12/11 16:50:30 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
-      "\u001b[32m[12/11 16:50:30 d2.data.common]: \u001b[0mSerializing 1000 elements to byte tensors and concatenating them all ...\n",
-      "\u001b[32m[12/11 16:50:33 d2.data.common]: \u001b[0mSerialized dataset takes 274.77 MiB\n",
-      "\u001b[32m[12/11 16:50:33 d2.data.common]: \u001b[0mSerialized dataset takes 274.77 MiB\n",
-      "\u001b[32m[12/11 16:50:33 d2.data.build]: \u001b[0mMaking batched data loader with batch_size=2\n",
-      "\u001b[32m[12/11 16:50:33 d2.data.build]: \u001b[0mMaking batched data loader with batch_size=2\n",
-      "\u001b[32m[12/11 16:50:34 d2.checkpoint.detection_checkpoint]: \u001b[0m[DetectionCheckpointer] Loading from None ...\n",
-      "\u001b[32m[12/11 16:50:34 d2.checkpoint.detection_checkpoint]: \u001b[0m[DetectionCheckpointer] Loading from None ...\n",
-      "\u001b[32m[12/11 16:50:34 d2.engine.train_loop]: \u001b[0mStarting training from iteration 0\n",
-      "\u001b[32m[12/11 16:50:34 d2.engine.train_loop]: \u001b[0mStarting training from iteration 0\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/g4merz/.conda/envs/ddrailnv/lib/python3.9/site-packages/torch/functional.py:504: UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument. (Triggered internally at /data/miniconda3/envs/opence-1.7/conda-bld/pytorch-base_1672876060819/work/aten/src/ATen/native/TensorShape.cpp:3190.)\n",
-      "  return _VF.meshgrid(tensors, **kwargs)  # type: ignore[attr-defined]\n",
-      "/home/g4merz/.conda/envs/ddrailnv/lib/python3.9/site-packages/torch/functional.py:504: UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument. (Triggered internally at /data/miniconda3/envs/opence-1.7/conda-bld/pytorch-base_1672876060819/work/aten/src/ATen/native/TensorShape.cpp:3190.)\n",
-      "  return _VF.meshgrid(tensors, **kwargs)  # type: ignore[attr-defined]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<detectron2.solver.lr_scheduler.LRMultiplier object at 0x7ffd4e26a730>\n",
-      "saving test_informer\n",
-      "<detectron2.solver.lr_scheduler.LRMultiplier object at 0x7ffd50bb0b50>\n",
-      "Iteration:  5  time:  3.4086406230926514e-07 dict_keys(['loss_cls', 'loss_box_reg', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [1.6428552865982056, 0.39192748069763184, 0.6762235760688782, 0.14166457951068878, 0.4567740559577942, 0.4442746341228485] val loss:  0 lr:  [0.001]\n",
-      "Iteration:  10  time:  4.367902874946594e-07 dict_keys(['loss_cls', 'loss_box_reg', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.6014314293861389, 0.23572906851768494, 0.6588569283485413, 0.11689773201942444, 0.32303041219711304, 0.42529281973838806] val loss:  0 lr:  [0.001]\n",
-      "Iteration:  15  time:  4.6892091631889343e-07 dict_keys(['loss_cls', 'loss_box_reg', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [1.0693222284317017, 1.1618809700012207, 0.6674785017967224, 0.09169908612966537, 0.38417452573776245, 1.8377342224121094] val loss:  0 lr:  [0.001]\n",
-      "Iteration:  20  time:  4.2421743273735046e-07 dict_keys(['loss_cls', 'loss_box_reg', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [1.342248797416687, 0.42702192068099976, 0.6400438547134399, 0.09377384185791016, 0.34773707389831543, 0.8349498510360718] val loss:  0 lr:  [0.001]\n",
-      "saving test_informer\n",
+      "In launch function\n",
+      "World size: 1\n",
+      "\u001b[32m[12/19 00:05:04 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
+      "\u001b[32m[12/19 00:05:04 d2.data.common]: \u001b[0mSerializing 800 elements to byte tensors and concatenating them all ...\n",
+      "\u001b[32m[12/19 00:05:21 d2.data.common]: \u001b[0mSerialized dataset takes 220.12 MiB\n",
+      "\u001b[32m[12/19 00:05:21 d2.data.build]: \u001b[0mMaking batched data loader with batch_size=1\n",
+      "\u001b[32m[12/19 00:05:21 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
+      "\u001b[32m[12/19 00:05:21 d2.data.common]: \u001b[0mSerializing 200 elements to byte tensors and concatenating them all ...\n",
+      "\u001b[32m[12/19 00:05:23 d2.data.common]: \u001b[0mSerialized dataset takes 54.65 MiB\n",
+      "\u001b[32m[12/19 00:05:30 d2.checkpoint.detection_checkpoint]: \u001b[0m[DetectionCheckpointer] Loading from None ...\n",
+      "\u001b[32m[12/19 00:05:30 d2.engine.train_loop]: \u001b[0mStarting training from iteration 0\n",
+      "<detectron2.solver.lr_scheduler.LRMultiplier object at 0x7ff6a719f0d0>\n",
+      "saving deepdisc_informer\n",
       "Training full model\n",
-      "\u001b[32m[12/11 16:52:36 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
-      "\u001b[32m[12/11 16:52:36 d2.data.common]: \u001b[0mSerializing 1000 elements to byte tensors and concatenating them all ...\n",
-      "\u001b[32m[12/11 16:52:36 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
-      "\u001b[32m[12/11 16:52:36 d2.data.common]: \u001b[0mSerializing 1000 elements to byte tensors and concatenating them all ...\n",
-      "\u001b[32m[12/11 16:52:39 d2.data.common]: \u001b[0mSerialized dataset takes 274.77 MiB\n",
-      "\u001b[32m[12/11 16:52:39 d2.data.common]: \u001b[0mSerialized dataset takes 274.77 MiB\n",
-      "\u001b[32m[12/11 16:52:39 d2.data.build]: \u001b[0mMaking batched data loader with batch_size=2\n",
-      "\u001b[32m[12/11 16:52:39 d2.data.build]: \u001b[0mMaking batched data loader with batch_size=2\n",
-      "\u001b[32m[12/11 16:52:40 d2.checkpoint.detection_checkpoint]: \u001b[0m[DetectionCheckpointer] Loading from ./test_informer.pth ...\n",
-      "\u001b[32m[12/11 16:52:40 d2.checkpoint.detection_checkpoint]: \u001b[0m[DetectionCheckpointer] Loading from ./test_informer.pth ...\n",
-      "\u001b[32m[12/11 16:52:40 d2.engine.train_loop]: \u001b[0mStarting training from iteration 0\n",
-      "\u001b[32m[12/11 16:52:40 d2.engine.train_loop]: \u001b[0mStarting training from iteration 0\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/g4merz/.conda/envs/ddrailnv/lib/python3.9/site-packages/torch/functional.py:504: UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument. (Triggered internally at /data/miniconda3/envs/opence-1.7/conda-bld/pytorch-base_1672876060819/work/aten/src/ATen/native/TensorShape.cpp:3190.)\n",
-      "  return _VF.meshgrid(tensors, **kwargs)  # type: ignore[attr-defined]\n",
-      "/home/g4merz/.conda/envs/ddrailnv/lib/python3.9/site-packages/torch/functional.py:504: UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument. (Triggered internally at /data/miniconda3/envs/opence-1.7/conda-bld/pytorch-base_1672876060819/work/aten/src/ATen/native/TensorShape.cpp:3190.)\n",
-      "  return _VF.meshgrid(tensors, **kwargs)  # type: ignore[attr-defined]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<detectron2.solver.lr_scheduler.LRMultiplier object at 0x7ffd55330fd0>\n",
-      "saving test_informer\n",
-      "<detectron2.solver.lr_scheduler.LRMultiplier object at 0x7ffd72900fd0>\n",
-      "Iteration:  5  time:  5.229376256465912e-07 dict_keys(['loss_cls', 'loss_box_reg', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.6372207999229431, 0.21455144882202148, 0.6573141813278198, 0.11151286214590073, 0.35142552852630615, 0.30622947216033936] val loss:  0 lr:  [0.0001]\n",
-      "Iteration:  10  time:  6.00004568696022e-07 dict_keys(['loss_cls', 'loss_box_reg', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.6133354902267456, 0.27655208110809326, 0.641355574131012, 0.09860541671514511, 0.3502991497516632, 0.29034876823425293] val loss:  0 lr:  [0.0001]\n",
-      "Iteration:  15  time:  4.7497451305389404e-07 dict_keys(['loss_cls', 'loss_box_reg', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.8414332270622253, 0.2684668302536011, 0.6235514283180237, 0.09521963447332382, 0.3083551526069641, 0.5863118767738342] val loss:  0 lr:  [0.0001]\n",
-      "Iteration:  20  time:  4.100147634744644e-07 dict_keys(['loss_cls', 'loss_box_reg', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.716134786605835, 0.27059656381607056, 0.6358343958854675, 0.09750178456306458, 0.3424227237701416, 0.5577629208564758] val loss:  0 lr:  [0.0001]\n",
-      "saving test_informer\n",
-      "Inserting handle into data store.  model_Inform_DeepDISC: inprogress_test_informer.pkl, Inform_DeepDISC\n"
+      "In launch function\n",
+      "World size: 1\n",
+      "\u001b[32m[12/19 00:05:30 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
+      "\u001b[32m[12/19 00:05:30 d2.data.common]: \u001b[0mSerializing 800 elements to byte tensors and concatenating them all ...\n",
+      "\u001b[32m[12/19 00:05:42 d2.data.common]: \u001b[0mSerialized dataset takes 220.12 MiB\n",
+      "\u001b[32m[12/19 00:05:42 d2.data.build]: \u001b[0mMaking batched data loader with batch_size=1\n",
+      "\u001b[32m[12/19 00:05:43 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
+      "\u001b[32m[12/19 00:05:43 d2.data.common]: \u001b[0mSerializing 200 elements to byte tensors and concatenating them all ...\n",
+      "\u001b[32m[12/19 00:05:44 d2.data.common]: \u001b[0mSerialized dataset takes 54.65 MiB\n",
+      "\u001b[32m[12/19 00:05:45 d2.checkpoint.detection_checkpoint]: \u001b[0m[DetectionCheckpointer] Loading from ./deepdisc_informer.pth ...\n",
+      "\u001b[32m[12/19 00:05:45 d2.engine.train_loop]: \u001b[0mStarting training from iteration 0\n",
+      "<detectron2.solver.lr_scheduler.LRMultiplier object at 0x7ff6a7292820>\n",
+      "saving deepdisc_informer\n",
+      "Inserting handle into data store.  model_Inform_DeepDISC: inprogress_deepdisc_informer.pkl, Inform_DeepDISC\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<rail.core.data.ModelHandle at 0x7ffdef2359a0>"
+       "<rail.core.data.ModelHandle at 0x7ff6949d6fd0>"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "Inform.inform(training, metadatahandle)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "ebe37e07-635f-4677-beac-2b978581646f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<rail.core.data.ModelHandle at 0x7ff6949d6fd0>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "m = Inform.get_handle(\"model\")\n",
+    "m\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "f6898f5c-a6b5-44ca-9621-1e1fdc227222",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import detectron2.checkpoint as checkpointer\n",
+    "\n",
+    "cfgfile=\"/home/shared/hsc/detectron2/configs/COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_1x.py\"\n",
+    "cfg = get_lazy_config(cfgfile, 1, 1)\n",
+    "\n",
+    "model = instantiate(cfg.model)\n",
+    "\n",
+    "# cp = checkpointer.DetectionCheckpointer(model,\"./\")\n",
+    "# # load weights\n",
+    "file_path = os.path.join(\"./\", \"deepdisc_informer\" + \".pth\")\n",
+    "# weights = cp.load(file_path)\n",
+    "# weights\n",
+    "\n",
+    "from fvcore.common.checkpoint import Checkpointer\n",
+    "fv_cp = Checkpointer(model, \"./\")\n",
+    "other_weights = fv_cp._load_file(file_path)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "fb810a68-37e8-432e-90e2-3263fddba8dc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "_IncompatibleKeys(missing_keys=[], unexpected_keys=[], incorrect_shapes=[])"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "cfgfile=\"/home/shared/hsc/detectron2/configs/COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_1x.py\"\n",
+    "cfg = get_lazy_config(cfgfile, 1, 1)\n",
+    "\n",
+    "model = instantiate(cfg.model)\n",
+    "fv_cp = Checkpointer(model, \"./\")\n",
+    "fv_cp._load_model(other_weights)"
    ]
   },
   {
@@ -378,7 +422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 19,
    "id": "7070dcb2-0de8-42af-af8d-f40c689b7cb1",
    "metadata": {},
    "outputs": [],
@@ -390,10 +434,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 20,
    "id": "7360caf2-5b3d-4998-be0c-3ca28fb5e035",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "StageConfig{cfgfile:/home/shared/hsc/detectron2/configs/COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_1x.py,batch_size:1,numclasses:1,epochs:20,output_dir:./,output_name:deepdisc_estimator,chunk_size:100,num_camera_filters:6,name:DeepDiscEstimator,model:<class 'rail.core.data.ModelHandle'> deepdisc_informer.pkl, (wd),num_gpus:1,config:None,input:None,metadata:None,aliases:{'output': 'output_DeepDiscEstimator', 'truth': 'truth_DeepDiscEstimator'},}"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Estimator = DeepDiscEstimator.make_stage(name='DeepDiscEstimator',\n",
     "#                                       model=Inform.get_handle('model'), **deep_dict)\n",
@@ -401,14 +456,15 @@
     "Estimator = DeepDiscPDFEstimator.make_stage(\n",
     "    name=\"DeepDiscEstimator\",\n",
     "    model=Inform.get_handle(\"model\"),\n",
-    "    # hdf5_groupname=\"images\",\n",
     "    **deep_dict,\n",
-    ")"
+    ")\n",
+    "Estimator.config\n",
+    "# Inform.get_handle(\"model\").has_data"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 21,
    "id": "c74bb222-f53c-415c-acab-f8b978a2af5d",
    "metadata": {},
    "outputs": [
@@ -416,12 +472,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "caching data\n",
-      "\u001b[32m[12/11 16:54:15 d2.checkpoint.detection_checkpoint]: \u001b[0m[DetectionCheckpointer] Loading from ./test_informer.pth ...\n",
-      "Processing Data\n",
-      "Matching objects\n",
-      "Inserting handle into data store.  output_DeepDiscEstimator: inprogress_output_DeepDiscEstimator.hdf5, DeepDiscEstimator\n",
-      "Inserting handle into data store.  truth_DeepDiscEstimator: inprogress_truth_DeepDiscEstimator, DeepDiscEstimator\n"
+      "Caching data\n"
+     ]
+    },
+    {
+     "ename": "TypeError",
+     "evalue": "return_predictor_transformer() got an unexpected keyword argument 'checkpoint'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[21], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m results \u001b[38;5;241m=\u001b[39m \u001b[43mEstimator\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mestimate\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtesting\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmetadatahandle\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/code/rail_deepdisc/src/rail/estimation/algos/deepdisc.py:372\u001b[0m, in \u001b[0;36mDeepDiscPDFEstimator.estimate\u001b[0;34m(self, input_data, input_metadata)\u001b[0m\n\u001b[1;32m    370\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mset_data(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124minput\u001b[39m\u001b[38;5;124m\"\u001b[39m, input_data)\n\u001b[1;32m    371\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mset_data(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmetadata\u001b[39m\u001b[38;5;124m\"\u001b[39m, input_metadata)\n\u001b[0;32m--> 372\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    373\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mfinalize()\n\u001b[1;32m    374\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mget_handle(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124moutput\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
+      "File \u001b[0;32m~/code/rail_deepdisc/src/rail/estimation/algos/deepdisc.py:418\u001b[0m, in \u001b[0;36mDeepDiscPDFEstimator.run\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    415\u001b[0m cfg_loader \u001b[38;5;241m=\u001b[39m get_loader_config(output_dir, batch_size)\n\u001b[1;32m    416\u001b[0m cfg\u001b[38;5;241m.\u001b[39mtrain\u001b[38;5;241m.\u001b[39minit_checkpoint \u001b[38;5;241m=\u001b[39m os\u001b[38;5;241m.\u001b[39mpath\u001b[38;5;241m.\u001b[39mjoin(output_dir, output_name) \u001b[38;5;241m+\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m.pth\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m--> 418\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpredictor \u001b[38;5;241m=\u001b[39m \u001b[43mreturn_predictor_transformer\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcfg\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcheckpoint\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mnnmodel\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    420\u001b[0m \u001b[38;5;66;03m# Process test images same way as training set\u001b[39;00m\n\u001b[1;32m    421\u001b[0m mapper \u001b[38;5;241m=\u001b[39m RedshiftDictMapper(\n\u001b[1;32m    422\u001b[0m     DC2ImageReader(), \u001b[38;5;28;01mlambda\u001b[39;00m dataset_dict: dataset_dict[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mfilename\u001b[39m\u001b[38;5;124m\"\u001b[39m]\n\u001b[1;32m    423\u001b[0m )\u001b[38;5;241m.\u001b[39mmap_data\n",
+      "\u001b[0;31mTypeError\u001b[0m: return_predictor_transformer() got an unexpected keyword argument 'checkpoint'"
      ]
     }
    ],
@@ -431,21 +495,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "5b402ba2-3779-44e7-8654-113f19731464",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<qp.ensemble.Ensemble at 0x7ffdcc507550>"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "res = results.read()\n",
     "res"
@@ -453,7 +506,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "41d2b4a5-0422-4f8f-8e08-49811549c46a",
    "metadata": {},
    "outputs": [],
@@ -463,7 +516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "94da4c4a-93c6-4203-a1b3-4fe186bad242",
    "metadata": {},
    "outputs": [],
@@ -473,7 +526,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "b958d33f-c330-4149-aa97-fe1970555bc6",
    "metadata": {},
    "outputs": [],
@@ -483,7 +536,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "18e185eb-397a-41b8-978e-871a9f624cab",
    "metadata": {},
    "outputs": [],
@@ -501,7 +554,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "f7417fa3-0c51-4a04-837c-f9e54431eeda",
    "metadata": {},
    "outputs": [],
@@ -511,78 +564,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "e7ba5ca0-7ded-4b4c-ac63-264c8c23ec98",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:root:Number of pit samples is smaller than the evaluation grid size. Will create a new evaluation grid with size = number of pit samples\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Inserting handle into data store.  input: None, DeepDiscEvaluator\n",
-      "Inserting handle into data store.  output_DeepDiscEvaluator: inprogress_output_DeepDiscEvaluator.hdf5, DeepDiscEvaluator\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "eval_res = DeepEvaluator.evaluate(res, truth)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "6cf80908-9582-45ca-b78f-f5163fb415a7",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'PIT_AD_stat': array([-0.03483239]),\n",
-       " 'PIT_AD_pval': array([nan]),\n",
-       " 'PIT_AD_significance_level': array([0.25]),\n",
-       " 'PIT_CvM_stat': array([0.36981175]),\n",
-       " 'PIT_CvM_pval': array([nan]),\n",
-       " 'PIT_CvM_significance_level': array([nan]),\n",
-       " 'PIT_KS_stat': array([0.15270281]),\n",
-       " 'PIT_KS_pval': array([nan]),\n",
-       " 'PIT_KS_significance_level': array([nan]),\n",
-       " 'PIT_OutRate_stat': array([nan]),\n",
-       " 'PIT_OutRate_pval': array([nan]),\n",
-       " 'PIT_OutRate_significance_level': array([nan]),\n",
-       " 'CDE_stat': array([-0.39996333]),\n",
-       " 'CDE_pval': array([nan])}"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "eval_res.data"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "f874ba48-786b-46d9-845d-d659c86cdc78",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:root:Number of pit samples is smaller than the evaluation grid size. Will create a new evaluation grid with size = number of pit samples\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from qp.metrics.pit import PIT\n",
     "from utils import *  # plot_pit_qq, ks_plot\n",
@@ -593,7 +598,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "e6de28b4-61c2-4d6f-ab20-46a0d369364f",
    "metadata": {},
    "outputs": [],
@@ -742,7 +747,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "ee26258c-8401-45ed-a75d-92da6ed7f41b",
    "metadata": {},
    "outputs": [],
@@ -875,30 +880,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "7a1263c0-1b38-4042-956c-902f1065c611",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:root:Number of pit samples is smaller than the evaluation grid size. Will create a new evaluation grid with size = number of pit samples\n",
-      "/tmp/ipykernel_3126226/663945040.py:80: MatplotlibDeprecationWarning: The legendHandles attribute was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use legend_handles instead.\n",
-      "  for item in leg.legendHandles:\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAccAAAHmCAYAAAAGDEUhAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/SrBM8AAAACXBIWXMAAA9hAAAPYQGoP6dpAACgkElEQVR4nOzdd1xV5R/A8c9lIwJuxL13uUjFPVJzm1aW5kpNU7M0M81+zspMM7Oc5Whomnub5t4T08SVe4ADFRAFBJ7fH0duXLjAvXAH4/t+ve5L73Of55zvYZwv55xn6JRSCiGEEELoOdg7ACGEECKjkeQohBBCJCLJUQghhEhEkqMQQgiRiCRHIYQQIhFJjkIIIUQikhyFEEKIRCQ5CiGEEIlIchRCCCESkeQoMrxFixah0+n0LycnJ4oUKULv3r25deuWvt6uXbvQ6XSsWLECwKBNSq9du3aluP+IiAi++uorqlevTs6cOcmZMyfVq1dn8uTJPH361GJt0iMwMJBx48Zx9epVi287PcaNG4dOp0tT2yVLljB9+nTLBiSEiZzsHYAQplq4cCEVKlTg6dOn7Nmzh0mTJrF7925Onz6Nh4dHkvoHDx40eD9x4kR27tzJjh07DMorVaqU7D7v3LnDyy+/zKVLlxgyZAhff/01ADt27GD8+PEsW7aMrVu3ki9fvnS1Sa/AwEDGjx9P48aNKVGihMW2a09Llizhn3/+4cMPP7R3KCIbkuQoMo0qVarg5+cHQJMmTYiNjWXixImsWbOGbt26Jalfp04dg/f58+fHwcEhSXlKevTowblz59i5cyf169fXlzdv3pw2bdrQpEkT+vTpw9q1a9PVRgiRschtVZFpxSe5a9euWWX7x44dY+vWrfTp08cgycWrX78+77zzDuvWrePvv/9Oc5v0WrRoEa+//jqg/dEQf7t40aJF+joLFiygatWquLm5kSdPHl599VXOnj2r//zXX39Fp9MludoGmDBhAs7Ozty+fTvFODZu3Ei1atVwdXWlZMmSTJ061Wi9mTNn0rBhQwoUKICHhwcvvPACX3/9Nc+ePdPXady4MRs3buTatWsGt8DjjR8/ntq1a5MnTx68vLyoUaMG8+fPR9ZREJYiyVFkWv/++y+gXRFaw7Zt2wDo2LFjsnXiP9u6dWua26RXmzZt+PLLLwEt8Rw8eJCDBw/Spk0bACZNmkSfPn2oXLkyq1at4rvvvuPUqVP4+/tz8eJFALp06ULBggWZOXOmwbZjYmKYO3cur776KoUKFUo2hu3bt9OhQwc8PT1ZunQpU6ZM4Y8//mDhwoVJ6l66dImuXbvy66+/smHDBvr06cOUKVPo37+/vs6sWbOoV68eBQsW1B9PwsR99epV+vfvzx9//MGqVavo1KkT77//PhMnTkz7F1KIhJQQGdzChQsVoA4dOqSePXumwsPD1YYNG1T+/PmVp6enCg4OVkoptXPnTgWo5cuXG91Oz549lYeHh8n7HTBggALUuXPnkq1z9uxZBahBgwaluY0lLF++XAFq586dBuUPHz5U7u7uqnXr1gbl169fV66urqpr1676srFjxyoXFxd1584dfdmyZcsUoHbv3p3i/mvXrq0KFSqknj59qi8LCwtTefLkUSmdZmJjY9WzZ8/UL7/8ohwdHdWDBw/0n7Vp00YVL148xf0m3MaECRNU3rx5VVxcXKpthEiNXDmKTKNOnTo4Ozvj6elJ27ZtKViwIJs3b8bHxyfN21RKERMTY/Aytz1gVo9MU9qkN654Bw8e5OnTp/Tq1cugvGjRojRt2pTt27fry9577z0AfvzxR33ZDz/8wAsvvEDDhg2T3UdERARHjx6lU6dOuLm56cs9PT1p165dkvoBAQG0b9+evHnz4ujoiLOzMz169CA2NpYLFy6YdFw7duzg5ZdfxtvbW7+NMWPGEBISwt27d03ahhApkeQoMo1ffvmFo0ePEhAQwO3btzl16hT16tVL1zZ//vlnnJ2dDV7xihUrBsCVK1eSbR8/dKJo0aJpbmNuXOYICQkBwNfXN8lnhQoV0n8O4OPjQ5cuXZg7dy6xsbGcOnWKvXv3Mnjw4BT38fDhQ+Li4ihYsGCSzxKXXb9+nQYNGnDr1i2+++479u7dy9GjR/W3c00Z5nLkyBFatGgBaIl8//79HD16lNGjR5u8DSFSI71VRaZRsWJFfW9VS2nXrh1Hjx41+lmLFi349NNPWbNmDa+88orROmvWrAGgadOmaW5jblzmyJs3LwBBQUFJPrt9+3aS4SQffPABv/76K2vXrmXLli3kypXLaE/ghHLnzo1OpyM4ODjJZ4nL1qxZQ0REBKtWraJ48eL68pMnT5p6SCxduhRnZ2c2bNhgcKUa/3UVwiLse1dXiNTFP3M8evRoivUs/cxRKaVatmypnJyc1L59+5J8tnfvXuXk5KTq1auX7jbptW7dOgWoTZs2GZTHP3Ns3769QfmNGzeUq6ur6tatW5Jt1a1bV9WqVUvlyJFDffjhhybt39RnjjNmzFCACgoK0pfFxcWpWrVqJXlm2qlTJ1WgQIEk+xo2bJjKmTOnio6O1pc9efJEFStWTAHqypUrJsUsRErktqoQKfj5558pX748LVq0YNSoUfz111/89ddffPrpp7Rs2ZKCBQuybNmydLdJrypVqgAwb9489u3bx7FjxwgJCSFXrlz873//Y926dfTo0YPNmzfz22+/0aRJE9zc3Bg7dmySbX3wwQccOXKEp0+fMnDgQJP2P3HiRIKDg2nevDlr1qxh5cqVNGvWLMnkDM2bN8fFxYW33nqLzZs3s3r1alq2bMnDhw+TbPOFF17g7t27zJ49myNHjnDs2DFA6537+PFjunbtyrZt21i6dCkNGjTA1dXV3C+bEMmzd3YWIjX2vHJUSqnHjx+rL774QlWtWlXlyJFDAQpQHTp0MOhdmd426TV9+nRVsmRJ5ejoqAC1cOFC/Wc//fSTevHFF5WLi4vy9vZWHTp0UGfOnDG6naioKOXq6qpeeeUVs/a/bt06/T6KFSumvvrqKzV27NgkvVXXr1+vqlatqtzc3FThwoXVxx9/rDZv3pzkyvHBgwfqtddeU7ly5VI6nc5gOwsWLFDly5dXrq6uqlSpUmrSpElq/vz5cuUoLEanlIyaFcIcYWFhNGrUiDt37rB3715Kly5tlTb2sn79etq3b8/GjRtp3bq1vcMRwi4kOQqRBsHBwdStW5e4uDj27t2bYs/T9LSxpcDAQK5du8YHH3yAh4cHJ06cSPOk4UJkdpIchRCANmXb/v37qVGjBj///DMVKlSwd0hC2I0kRyGEECKRLNtbdc+ePbRr145ChQqh0+lMGgO1e/duatasiZubG6VKlWLOnDnWD1QIIUSGk2WTY0REBFWrVuWHH34wqf6VK1do3bo1DRo0ICAggE8//ZQhQ4awcuVKK0cqhBAio8kWt1V1Oh2rV69OcaWETz75hHXr1hks4zNgwAD+/vtvo8v4CCGEyLpk+rjnDh48qJ+vMV7Lli2ZP38+z549Mzq3ZVRUFFFRUfr3MTExnD17lqJFi+LgkGUvyoUQ2UhcXBx37tyhevXqODlln5SRfY40FcHBwUlWd/Dx8SEmJob79+8bnbh50qRJjB8/3lYhCiGE3Rw5coSXXnrJ3mHYjCTHBBKP6VKpLC00atQohg0bpn9/48YNqlSpwpEjR4wmUyGEsKk7d2DvXjh4EI4cgecrwqTkHvAOcDJReXqWhsuMJDk+V7BgwSQrCNy9excnJyf9ygaJubq6Gszn6O3tDWjLAxUpUsR6wQohRHJu3YIZM2DTJvjnH7OangY6Atefv/fQ6fi+TBneuXgx2z0qkuT4nL+/P+vXrzco27p1K35+fmleS08IIWwmLg5++gk+/hjCwlKv7+gIb70FdetCnjxsuniRLpMm8fjJEwCKFCnC+vXrtWXNMthsTraQZZPj48eP+ffff/Xvr1y5wsmTJ8mTJw/FihVj1KhR3Lp1i19++QXQeqb+8MMPDBs2jH79+nHw4EHmz5/P77//bq9DEEII0wQEwLBhsGtX6nW9vKB7dxg+HEqUALTzZe/SpfWJ0c/Pj3Xr1uHr68vNmzetF3cGlmWT47Fjx2jSpIn+ffyzwZ49e7Jo0SKCgoK4fv26/vOSJUuyadMmhg4dysyZMylUqBAzZsygc+fONo9dCCFSdf8+rFkDc+fC8+W8jPLygqZNoVEjaNgQXnwREvU6zZkzJ8uXL+fll1+mffv2/PLLL+TIkcO68Wdw2WKco63cvHmTokWLcuPGjRSfOcbGxvLs2TMbRiZM5ezsjKOjo73DEOI/SkFICPz7L1y6BH//Ddu3a1eLKZ2+e/SAAQPgpZeSJMPkHD9+nOrVqxs8XzT1vJbVZNkrx4xIKUVwcDCPHj2ydygiBbly5aJgwYKyIoWwj+hoWLQIVq6E69fhxg2IiDC9fbFiMG8etGyZbJUrV67w448/8sUXXxj8nNesWTMdgWctkhxtKD4xFihQgBw5csjJN4NRSvHkyRPu3r0LIMNxhO1FRECnTrB1q/ltCxeGfv20Z4+enslWO3DgAB07duTevXu4uLgwbty4tMdrxOzZs5k9ezZXnw8bqVy5MmPGjKFVq1bJttm9ezfDhg3jzJkzFCpUiBEjRjBgwACLxmUuSY42Ehsbq0+MyQ0NEfbn7u4OaMN4ChQoILdYhe2EhECbNnD4sOltcuSA5s2hb1945ZVUb58uWbKEd955Rz+z17JlyxgxYoRFny8WKVKEr776ijJlygDw888/06FDBwICAqhcuXKS+vHzWvfr14/ffvuN/fv3M3DgQPLnz2/XPh+SHG0k/hljdn/InRnEf4+ePXsmyVHYRlAQNGsGCeZ2TsLJCUqWhNKlwc9PS4p16oCLS6qbV0oxfvx4gxm9mjZtyooVKyx+TmrXrp3B+y+++ILZs2dz6NAho8lxzpw5FCtWjOnTpwNQsWJFjh07xtSpUyU5ZidyKzXjk++RsKm4OOjSJWlizJsXvv4aypbVxhkWKWJyx5qEIiMjeeeddwyGpfXr14+ZM2dafQx3bGwsy5cvJyIiAn9/f6N10jKvtS1IchRCCHv68UdtireEihTRnjtWrJiuTd+5c4dXX31Vv7KQTqdj6tSpDB061Ow/AsPDwwlLMLlA4hnCEjp9+jT+/v5ERkaSM2dOVq9eTaVKlYzWTcu81rYgyTGD6bPoqMH7+b2yz0S/GVXC70ly3w9T6giRxO3bMGKEYVnx4rBnj9brNB0uXrxI8+bNuXbtGgAeHh4sWbKEtQ986fuzNi7SlJ/n8S9rySlxchs7dmyynXnKly/PyZMnefToEStXrqRnz57s3r072QRp7rzWtpC9JsvLwHr16oVOp2P9hg1s2LiRrVu3cujQIRYsWEBcXJzN49HpdPqXh4cHZcuWpVevXhw/ftyg3q5du9DpdAbDU+bOnUvVqlXx8PAgV65cVK9encmTJxu0CwsLY/To0VSoUAE3NzcKFizIyy+/zKpVq5ChtyLbGDIk6VRvP/6Y7sQIUKBAATw8PAAoXLgw+/bto3379mneXmBgIKGhofrXqFGjkq3r4uJCmTJl8PPzY9KkSVStWpXvvvvOaN20zGttC3LlmIG88sor5GneHJQiKiqKu/fu8sEH/VmxYgXr1q2z+VpqCxcu5JVXXiEyMpILFy4wb948ateuzYIFC+jRo4fRNvPnz2fYsGHMmDGDRo0aERUVxalTpwgMDNTXefToEfXr1yc0NJTPP/+cl156CScnJ3bv3s2IESNo2rQpuXLlstFRCmEnf/yhjWVMqHt3raONBXh7e7NhwwYGDRrETz/9RKFChdK1PU9PT7y8vNLUVj0/pxmTUee1livHDMTV1RU3V1fc3Nzw9vambJmyrF27ls2bN7No0SIAQkNDeffddylQoABeXl40bdqUv//+22A769evp2bNmri5uVGqVCnGjx9PTEyM/nOdTsfs2bNp1aoV7u7ulCxZkuXLlyeJJ34wfIkSJWjRogUrVqygW7duDB48mIcPHxo9hvXr1/PGG2/Qp08fypQpQ+XKlXnrrbeYOHGivs6nn37K1atXOXz4MD179qRSpUqUK1eOfv36cfLkSXLmzGmBr6YQGdSzZ/DZZ/Dmm4blefPCtGlp3mxMTAwPHjwwKIufFjO9idEcn376KXv37uXq1aucPn2a0aNHs2vXLrp16wZoS/0l/ON6wIABXLt2jWHDhnH27FkWLFjA/PnzGT58uM1iNkaSYwbXtGlTqlatqr/d2KZNG4KDg9m0aRPHjx+nRo0aNGvWTP9L8eeff/L2228zZMgQAgMDmTt3LosWLeKLL74w2O7//vc/OnfuzN9//83bb7/NW2+9xdmUupE/N3ToUMLDw9m2bZvRzwsWLMihQ4f0zzkSi4uLY+nSpXTr1s3oL2zOnDmz1WrjIpu5cUOb4/SLL5JO/fbtt5AvX5o2GxYWRrt27WjZsiVPnk8ebi937tyhe/fulC9fnmbNmnH48GG2bNlC8+dXxMnNa71r1y6qVavGxIkTM8S81nIWygQqVKjAqVOn2LlzJ6dPn+bu3bv6XmJTp05lzZo1rFixgnfffZcvvviCkSNH0rNnTwBKlSrFxIkTGTFiBGPHjtVv8/XXX6dv374ATJw4kW3btvH9998za9asVGMB9LNfJDZ27Fg6depEiRIlKFeuHP7+/rRu3ZrXXnsNBwcH7t+/z8OHD/XbESLbCA/XJgBPsFqQ3ltvwdtvp2mzV69epW3btpw5cwaAvn37smTJkvREmi7z589P8fP4u2AJNWrUiBMnTlgporSR5JgJKKXQ6XQcP36cx48fJ3lI/fTpUy5dugRoEwcfPXrU4EoxNjaWyMhInjx5oh/wm3jMkb+/PydPnjQpFki+F5mvry8HDx7kn3/+Yffu3Rw4cICePXvy008/sWXLlgzRC00Iuxg+PGlidHLSriKHD4c0/E4cPHiQjh076qc8zJ07N++++64los32JDlmAmfPnqVkyZLExcXh6+vLLiNrtsV3YImLi2P8+PF06tQpSR03N7cU92NKwoq/9VqyZMkU61WpUoUqVaowaNAg9u3bR4MGDdi9ezeNGjUid+7cJt3CFSLL2LxZmww8odKl4ffftVUz0mDp0qX06tVL39GlbNmybNy4kbJly6Y3WoEkxwxvx44dnD59mqFDh1KkSBGCg4NxcnKixPNFShOrUaMG58+f189rmJxDhw4ZPBQ/dOgQ1atXTzWe6dOn4+Xlxcsvv2zyMcSPbYqIiMDBwYEuXbrw66+/Mnbs2CTPHSMiInB1dZXnjiLrePAA+vQxLPPw0Ab5lypl9uaUUkyYMMFgjGHjxo1ZuXIlefLkSWewIp6cgTKQqKgoIqOiDIZydHi/P23btqVHjx44ODjg7+9Px44dmTx5MuXLl+f27dts2rSJjh074ufnx5gxY2jbti1Fixbl9ddfx8HBgVOnTnH69Gk+//xz/b6WL1+On58f9evXZ/HixRw5ciTJs4JHjx4RHBxMVFQUFy5cYO7cuaxZs4Zffvkl2aEW7733HoUKFaJp06YUKVKEoKAgPv/8c/Lnz6+/lfvll1+ya9cuateuzRdffKHvsr13714mTZrE0aNHZSiHyDoGD9bmTk3om2/SlBgjIyPp06ePwTPFd955h9mzZ+NiwhyrwnSSHDOQLVu2kN+jFjqdDhdnZ7y8vJgxYwY9e/bULz66adMmRo8ezTvvvMO9e/coWLAgDRs21E+/1LJlSzZs2MCECRP4+uuvcXZ2pkKFCvrON/HGjx/P0qVLGThwIAULFmTx4sVJZq/o3bs3oN2OLVy4MPXr1+fIkSPUqFEj2WN4+eWXWbBgAbNnzyYkJIR8+fLh7+/P9u3b9c9Kc+fOzaFDh/jqq6/4/PPPuXbtGrlz5+aFF15gypQpeHt7W+xrKoRdrV6t3TpN6JVXII3PBefOnatPjDqdjsmTJzN8+HB5hm8FOiXTkVhMSitmR0ZGcuXKFUqWLJnisz9bTB+n0+lYvXo1HTt2tPi2s4LE3yuZPk6kyYMHUKkS3LnzX1muXPDPP9rai2kQGxtLhw4d2LlzJ4sXL07T77C5P8/jX/ZN9ryWlcmVoxBCWMPQoYaJEeD779OcGAEcHR35/fffuXz5MlWrVk1ngCIlMgmAEEJY2qZN8MsvhmVt2sDzWWJMNWfOHI4dO2ZQ5unpKYnRBuTKMRuSO+lCWEFUFKxfD8uWwYYNhp95ecGcOSaPZYyNjdXPUezr68uRI0ey1S3NjECuHIUQIr1CQ6FmTXj9dVixAiIjDT//5httjUYThIWF0b59e2bMmAFo062tXr3a0hGLVMiVoxBCpNfcufB8+rYkXn456TjHZFy7do22bdvyzz//AODk5MScOXPoY2J7YTmSHIUQIr3+/DNpmZOTNmfqzJkm3U49fPgwHTp04M7zTjy5c+dm5cqVNGnSxNLRChPIbdUMpFevXqzfsEG/4PH2HdsZPnw4ERER+s/ju24nXIzY2KtXr142jX3WrFn6oQ81a9Zk7969FmljyzpCpMnTp7B/v2HZ6NEQHKx1yvH0THUTf/zxB40bN9YnxjJlynDo0CFJjHYkyTGDKZA/P82bN6dZs6ZUKF+BWbNmGV3XLCgoSP+Kn9ItYVlyq25bw7Jly/jwww8ZPXo0AQEBNGjQgFatWhksS5OWNrasI0Sa7d+vdcaJ5+AAH3+src9ogq+++oouXboQ+fw5ZaNGjTh06BDlypWzRrTCRJIcMxgHRwfcXF1xd3OncOHCdOvWjTVr1iSpV7BgQf3L29sbnU6XpMxWpk2bRp8+fejbty8VK1Zk+vTpFC1alNmzZ6erjS3rCJFmf/1l+P6ll8CM378CBQro/9+7d2+2bt2aZOUdYXuSHDM4d3d3nj17Zrf9L1q0KMWpqaKjozl+/DgtWrQwKG/RogUHDhxIcxtb1hEiXbZvN3xvxqT8oM2NOnLkSL766ivmz58vc6RmENIhJwN7+OgRa5csoVmzZjbb5+XLlzlz5gzt2rUDwNvbm/Llyydb//79+8TGxurndo3n4+NDcHBwmtvYso4QafbgARw/bliWSnJ88OBBktUzJk2aZOnIRDrJlWMGc+fOHTZv3szGTZvYv28fDRs25Pvvv7fZ/jdv3sy5c+f071999VWD98lJfHUZv0BzetvYso4QZtu1CxJOquHuDokWEk9o27ZtlC5dmmXLllk/NpEukhwzmHx589GwYUOaNGlC6zatWbVqlcEzCXOdPn0af39/qlSpQufOnYmOjgbgxRdf5OHDhwDs37+fnj17snv3bj777DN+/PFHqlevztOnT1OPN18+HB0dk1yF3b17N8nVmjltbFlHiDRL/LyxQQNwdTVadc6cObRq1YpHjx7Rs2dPjie+4hQZiiTHDMbRyREPDw9yuLvjoEvftycyMpK33nqLn3/+mX/++Yd8+fKxdOlSYmJiePz4Mblz5wbg1KlTVK5cmUaNGlGlShW2b99OQEAA7u7uqe7DxcWFmjVrsm3bNoPybdu2Ubdu3TS3sWUdIdIscXI08ggkNjaWoUOH8t577xEbGwtoS8ul9LhC2J88c8zC1qxZwyuvvKLvEl6hQgXu3bvH+fPnDbqJnzp1irZt2wL/LbsVb/Xq1YwaNSrFW6vDhg2je/fu+Pn54e/vz7x587h+/ToDBgzQ1/nhhx9YvXo12593XjCljS3rCGG269fh4kXDskTPG8PDw+natSsbEsy1+tFHHzF58mQcHR1tEaVII0mOWdjZs2epWLGi/v2ZM2fo3Lkz//zzD1WqVNGXHzt2jJEjR3Lz5k0KJ1pOJzQ0lPPnz6e4ny5duhASEsKECRMICgqiSpUqbNq0ieLFi+vr3L9/n0uXLpnVxpZ1hDBb4l6qefJAtWr6tzdu3KBt27acOnUK0KaCmzVrFv369bNhkCKtZLFjC8poix3PmTOHS5cuMWXKFE6cOEGvXr0ICAhg3rx53L59m4kTJ7Jnzx7atm1LaGgo+/bt4/vvv+ePP/5I8z6zAlnsWJjk7bdh8eL/3r/2GixfDsCRI0fo0KGD/ll3rly5WLFihU17nidHFjs2jVw5ZmHdu3fnjTfe4IUXXiB37tz88ccfODo68sorr9CuXTsuXbpEmTJlqFixIjqdjipVqnDx4kVeeOEFli9fToUKFex9CEJkTEolvXJ8nviio6N57bXX9ImxdOnSbNiwQX6fMhlJjlmYh4cHGzduTFJesmRJ/az/ABMmTAC0iY4DAgJsFp8QmVZgoDZ3akLPnze6uLiw5Pn45Nq1a7Nq1Sry5ctnhyBFekhyFEIIcyXupVq8OJQurX9bv359tm/fzksvvYRrMkM7RMYmQzmEEMJcCW6p3gcm5s1LXKLuG/Xr15fEmIlJchRCCHPExGgz4wDngDrAmBMnGDt2rD2jEhYmyVEIIcxx9CiEh7Md8AfiByjNnz9fP+uUyPyydHI0d4HbxYsXU7VqVXLkyIGvry+9e/cmJCTEojHJyJmMT75HIkV//cWPwCvAo+dFVatW5fDhw/pZp0Tml2WTo7kL3O7bt48ePXrQp08fzpw5w/Llyzl69Ch9+/a1SDzOzs4APHnyxCLbE9YT/z2K/54JES82NpaP5s7lXSDmeVnbkiXZt2+fwcxSIvPLsr1VEy5wCzB9+nT+/PNPZs+ebXR5mEOHDlGiRAmGDBkCaMMd+vfvz9dff22ReBwdHcmVKxd3794FIEeOHEZXhYiNizN4H786uLA+pRRPnjzh7t275MqVS6b3EgYeP35MtzffZN2tW/qyYcDX06fjmDOn/QLLYCZNmsSqVas4d+4c7u7u1K1bl8mTJ6c4l+yuXbto0qRJkvKzZ8/abXxolkyO8Qvcjhw50qA8pQVu69aty+jRo9m0aROtWrXi7t27rFixgjZt2lgsroIFCwLoE6Qxia8sr1y5YrH9C9PkypVL/70SAiAoKIjWrVtz8uRJAByBWcC7Tk5g5KSene3evZtBgwbx0ksvERMTw+jRo2nRogWBgYF4eHik2Pb8+fN4eXnp3+fPn9/a4SYrSybHtCxwW7duXRYvXkyXLl2IjIwkJiaG9u3bp7iWYlRUFFFRUfr34eHhKcal0+nw9fWlQIECPHv2zGidHDnCDN6XLFkyxW0Ky3J2dpYrRpGEh4cHMTHajVRvYAXwMkDt2uDpacfIMp4tW7YYvF+4cCEFChTg+PHjNGzYMMW2BQoUIFeuXFaMznRZMjnGM2eB28DAQIYMGcKYMWNo2bIlQUFBfPzxxwwYMID58+cbbTNp0iTGjx9vdlyOjo7JnoAdHQwfA6c0D6sQwja8vLzY8PvvdK1enfkxMehv9CVahSMrCw8PJyzsvz/eXV1dTRrHGRoaCkCePHlSrVu9enUiIyOpVKkSn332mdFbrbaSJTvkpGWB20mTJlGvXj0+/vhjXnzxRVq2bMmsWbNYsGABQUFBRtuMGjWK0NBQ/SswMNDixyKEsD2llEEiACi+bh37EiZGgE6dbBqXPVWqVAlvb2/9y1jfjcSUUgwbNoz69esbrASUmK+vL/PmzWPlypWsWrWK8uXL06xZM/bs2WPJQzBLlrxyTLjA7auvvqov37ZtGx06dDDa5smTJzg5GX454q/ukuvan/gvp8S/TEKIzCc6Opr+/ftz6tQp9uzZoz0nCwuDb77B4L5Tx47w4ot2itL2AgMDDZa0M+WqcfDgwZw6dYp9+/alWK98+fIGHXb8/f25ceMGU6dOTfVWrLVkyStH0Ba4/emnn1iwYAFnz55l6NChBgvcjho1ih49eujrt2vXjlWrVjF79mwuX77M/v37GTJkCLVq1aJQoUL2OgwhhA2FhITQvHlzFi1axIkTJ+jRo4f2x/EPP8CDB4aVx4yxT5B24unpiZeXl/6VWnJ8//33WbduHTt37kzTUld16tThYuLFpG0oS145QuoL3AYFBRmMeezVqxfh4eH88MMPfPTRR+TKlYumTZsyefJkex2CEMKGzp8/T9u2bfn3338B7Xl/ly5d0IWHwzffGFbu2BGqV7d9kJmAUor333+f1atXs2vXrjR3KgwICMDX19fC0ZkuyyZHgIEDBzJw4ECjny1atChJ2fvvv8/7779v5aiEEBnNzp076dSpE48ePQK0nu1r166ldu3a8OWXSa8aZR7VZA0aNIglS5awdu1aPD099X0/vL29cXd3B7Q7d7du3eKXX34BtHHoJUqUoHLlykRHR/Pbb7+xcuVKVq5cabfjyNLJUQghUjN//nwGDBigH6rxwgsvsH79eu0uU3Q0zJhh2ODVV6FaNdsHmknMnj0bgMaNGxuUL1y4kF69egFJ79xFR0czfPhwbt26hbu7O5UrV2bjxo20bt3aVmEnIclRCJEtxcbGMmrUKKZMmaIva9OmDb///jue8WMXV6+GO3cMG/7vfzaMMvMxZW7ixHfuRowYwYgRI6wUUdpk2Q45QgiRkl9//dUgMX7wwQf6W4F6s2YZNmrYUJ41ZhOSHIUQ2VL37t1p3749jo6OzJo1i+nTpxtOznHmDCQeZ/fee7YNUtiN3FYVQmRLjo6OLF68mBMnThgfS/f82ZlegQLZatB/didXjkKIbGHNmjUcOXLEoCxnzpzGE2N4ODzvSanXrx+4uFgxQpGRSHIUQmRpSim+/vprOnXqRPv27ZNd09XA4sVagozn4ADvvmu9IEWGI8lRCJFlRUdH07dvXz755BOUUty5c4effvop5UZKJe2I07YtFCtmvUBFhiPPHIUQWdKDBw/o3Lkzu3bt0pdNmDCBzz77LOWGf/0Fp08bliUzmYjIuiQ5CiGynIsXL9KmTRv93Jyurq78/PPPdOnSJfXGU6cavi9XDpo3t0KUIiOT5CiEyFJ27dpFp06dePjwIaAtoLt27Vrq1KmTeuNTp2DrVsOyjz7SnjmKbEW+40KILGPRokU0b95cnxirVKnCkSNHTEuMkHSC8fz5oXt3C0cpMgNJjkKILEOn0+nnSG3VqhX79+/Xr8STqps3YckSw7LBg+H5ZNkie5HbqkKILKNnz56cP3+eiIgIvvnmmyQLmKfo++/heWIFwM1NOuJkY5IchRCZVkREBB4eHgZlX3zxBTqdzrwNPXwIc+YYlvXuDfnypTNCkVnJbVUhRKYUEBBAhQoVWLx4sUG52YkRtB6qYWEJNwJDh6YzQpGZSXIUQmQ6a9eupX79+ty8eZN33nmHgwcPpn1jd+/Cd98Zlr3+OpQtm74gRaYmyVEIkWkopZg6dSqvvvoqT548AaBGjRqUKlUq7Rv96iuIiPjvvYMDjB+fzkhFZifJUQiRKTx79ox3332Xjz/+WL+g7ltvvcXOnTvx8fFJ20Zv3Uo6VVyPHlChQjqjFZmdJEchRIb38OFDXnnlFYN5UceOHcvixYtxc3NL+4Y//xyiov577+wMY8emI1KRVUhvVSFEhvbvv//Spk0bLly4AGhTwS1YsICuXbumb8PXrkHiScj79oUSJdK3XZElSHIUQmRYsbGxtGvXTp8Y8+fPz5o1a6hbt276N/7tt0nHNaY2KbnINuS2qhAiw3J0dGT+/Pm4urpSqVIlDh8+bJnEGBICP/5oWPbuu1CoUPq3LbIEuXIUQmRodevWZePGjfj5+eHt7W2Zjc6cCc97uwLg6AjDhllm2yJLkCtHIUSG8eTJE7799lvi4uIMyps1a2a5xPjkiTZVXEJvvQWmzsEqsgW5chRCZAhBQUG0b9+eY8eOce/ePb788kvr7GjBArh/37BsxAjr7EtkWnLlKISwu7///ptatWpx7NgxAH744Qdu375t+R1FRyddlqpVK3jhBcvvS2RqkhyFEHa1fv166tWrx82bNwEoXrw4Bw4coJClO8fExmoD/K9eNSz/5BPL7kdkCZIchRB2oZRi2rRpdOjQgYjn07fVrl2bw4cPU6VKFUvvTFubcdkyw/LataFhQ8vuS2QJkhyFEDb37NkzBgwYwEcffaSfCq5Lly7pmwouOUpp4xcTL0nl4aFNHZeWVTxElicdcoQQNvXo0SNef/11/vrrL33ZmDFjGDt2LA4OFv57/ckT6N8ffvvNsNzZGVavhho1LLs/kWVIchRC2JSjoyN3794FwMXFhQULFtCtWzfL7+jSJejUCU6dMix3cIAlS6B5c8vvU2QZcltVCGFTnp6erF+/nhdeeIEdO3ZYJzFeuwa1aiVNjABz58Jrr1l+nyJLkeQohLC6p0+fGrwvVqwYJ0+epF69etbZ4WefwYMHhmWentqt1L59rbNPAcCkSZN46aWX8PT0pECBAnTs2JHz58+n2m737t3UrFkTNzc3SpUqxZzEz4htTJKjEMJq4uLi+Oyzz6hbty6PHz82+MzizxfjhYXBypWGZZUqwdGj0LGjdfYp9Hbv3s2gQYM4dOgQ27ZtIyYmhhYtWuh7JBtz5coVWrduTYMGDQgICODTTz9lyJAhrEz8fbQheeYohLCKp0+f0rNnT5YvXw5A165dWbNmjfWSYrzlyyHhlaqTE+zYAZbuBSuM2rJli8H7hQsXUqBAAY4fP07DZIbNzJkzh2LFijF9+nQAKlasyLFjx5g6dSqdO3e2dshGyZWjEMLigoODady4sT4xOjg40KxZM3S2GDaxaJHh+zZtJDFaQHh4OGFhYfpXVMJFolMQGhoKQJ48eZKtc/DgQVq0aGFQ1rJlS44dO8azZ8/SHnQ6yJWjDfVZdNRo+fxeL9ktDlvv21gMiaUnpoxwbAlltHjA+jGdOnWKtm3bcuPGDQBy5szJ0qVLadOmjcX3lcS//8K+fYZlvXpZf79ZQEq/kwCVKlUyeD927FjGjRuXYhulFMOGDaN+/fopTuwQHBycZHyrj48PMTEx3L9/H19f35SDtwJJjkIIi9m4cSNvvvmm/vli0aJF2bBhAy+++KJtAvj5Z8P3+fJB69a22XcWFxgYSOHChfXvXV1dU20zePBgTp06xb7Ef7AYkfiuQvzkEDa522CEJEchRLoppfjuu+/46KOP9MtN1apVi7Vr11KwYEHbBBEXlzQ5dusGLi622X8W5+npiZeXl8n133//fdatW8eePXsoUqRIinULFixIcHCwQdndu3dxcnIib968aYo3veSZoxAi3dauXcvQoUP1ifGNN95g165dtkuMADt3wvNbuXpyS9XmlFIMHjyYVatWsWPHDkqWLJlqG39/f7Zt22ZQtnXrVvz8/HB2drZWqCmS5CiESLf27dvz6quvAvDZZ5/x+++/4+7ubrsAHj2CYcMMy158EapVs10MAoBBgwbx22+/sWTJEjw9PQkODiY4ONhgrOuoUaPo0aOH/v2AAQO4du0aw4YN4+zZsyxYsID58+czfPhwexwCkMWT46xZsyhZsiRubm7UrFmTvXv3plg/KiqK0aNHU7x4cVxdXSldujQLFiywUbRCZF4ODg78+uuvrFmzhokTJ1p/uEZCT59C+/ZJZ8ORq0a7mD17NqGhoTRu3BhfX1/9a1mCFVGCgoK4fv26/n3JkiXZtGkTu3btolq1akycOJEZM2bYbRgHZOFnjsuWLePDDz9k1qxZ1KtXj7lz59KqVSsCAwMpVqyY0TZvvPEGd+7cYf78+ZQpU4a7d+8SExNj48iFyPj279+Pk5MTtWvX1pd5eHjQoUMH2wYSEwNvvgmJ//AtUwb69bNtLAL4ryNNShYlHm4DNGrUiBMnTlghorTJsslx2rRp9OnTh77Pp4qaPn06f/75J7Nnz2bSpElJ6m/ZsoXdu3dz+fJl/XicEiVK2DJkITKFxYsX884775ArVy4OHz5sv9+TQ4fgvffg5EnD8oIF4c8/IWdOu4QlsoYMc1s1ICCASZMmMXbsWH799VdOnz5NbGxsmrYVHR3N8ePHkwwqbdGiBQcOHDDaZt26dfj5+fH1119TuHBhypUrx/Dhw5PMCZlQVFSUwaDY8PDwNMUrRGYQFxfHmDFjePvtt4mOjubu3btMmTLF9oE8egTvvgv+/kkTo7e3lhhLlbJ9XCJLyRBXjuvXr6dz587ExMTg5OSkT4ouLi5UqVKF6tWrU716dd577z2Ttnf//n1iY2ONDipN3F043uXLl9m3bx9ubm6sXr2a+/fvM3DgQB48eJDsc8dJkyYxfvx4M45UiMzp6dOn9OrViz/++ENf1r9/f/10XzZz8iR07gyXLyf9zM0N1q/XOuIIkU4Z4srx888/p3jx4ly7do0bN26glGLIkCE0bNiQ48ePM3/+fAYPHmz2do0NKk1uQGlcXBw6nY7FixdTq1YtWrduzbRp01i0aFGyV4+jRo0iNDRU/woMDDQ7RiEyuuDgYJo0aaJPjDqdjmnTpjF79mzbdrNftEi7WjSWGCtXhl27oEED28UjMoxnz57RpEkTLly4YLFtZojkeO7cOfr160fRokVxctIuZtu1a8eff/7JnDlzqFq1KkeOHDF5e/ny5cPR0dHooNLEV5PxfH19KVy4MN7e3vqyihUropTi5s2bRtu4urri5eWlf3l6epocoxCZwenTp6lduzaHDx8GtE438WMabTZzybNnMHAg9O4NkZGGn3l4wNSpEBAACToHiezF2dmZf/75x6I/kxkiOTo6Ouo7wbi5uQHac0OAd999l2LFirF69WqTt+fi4kLNmjWTDCrdtm0bdevWNdqmXr163L5922BZnQsXLuDg4JDq7A5CZEWbN2+mXr16+i73RYoUYd++fbRr1852QTx4AK+8ArNnJ/2sTh0IDISPPgI7DRQXGUePHj2YP3++xbaXIZ45lihRgqtXrwLaX6be3t4EBQXpP2/evDnTpk3j888/N3mbw4YNo3v37vj5+eHv78+8efO4fv06AwYMALRbordu3eKXX34BtOV0Jk6cSO/evRk/fjz379/n448/5p133rHtYGYhMoiQkBB9JzM/Pz/WrVtn2wmgz5+Hdu3g4sWkn73/vnbFKFPDieeio6P56aef2LZtG35+fnh4eBh8Pm3aNLO2lyGSY7NmzdiyZYs++b344ots3bqV3r17A/D48WODZGmKLl26EBISwoQJEwgKCqJKlSps2rSJ4sWLA0kHoebMmZNt27bx/vvv4+fnR968eXnjjTfMSshCZCVvv/0258+f5+zZs/zyyy/kyJHDdjs/fFibMPzBA8NyNzf46SdtzlQhEvjnn3+oUaMGQJJnj2m53ZohkuPQoUMpXrw4T58+xd3dnUGDBvHmm2/i4+NDuXLlmDZtWpLlUkwxcOBABg4caPQzY4NQK1SokORWrBDZRXR0NC6JrsTie2PbdMabv/6Cjh0h8crxvr6wZg3UqmW7WESmsXPnTotuL0M8cyxUqBCDBw/W375844036N+/PzNmzGDw4ME8e/bM9l3GhchGrly5Qo0aNfSPGeI5ODjYNjGuXKktTpw4MdaoAUeOSGIUqfr333/5888/9aMMTJmxx5gMkRw3btyoXy063uzZs7l8+TJ79uzhypUr1K9f307RCZG1HThwgNq1a3PmzBn69u2b6hzEVrN8ObzxBjzvjKfXsiXs2QPSMU6kICQkhGbNmlGuXDlat26tfxTXt29fPvroI7O3lyGSY/v27dm4cWOS8hIlSlC/fn2D4RVCCMtZsmQJTZs25d69e4A2AbQ9Vl1n7Vro2lVbkzGhLl1g3TptyIYQKRg6dCjOzs5cv37d4Pl4ly5d2LJli9nbyxDJMbXL3g0bNti2+7gQWZwCzl84T7du3YiKigKgadOmHDp0iDJlytgwEAWrVsHrr2uTiCc0YAAsXiw9UoVJtm7dyuTJk5MMvStbtizXrl0ze3t265Dz22+/cfz4cWo9f4aQUm+i0NBQNm3aZKvQhMjSYuPi+PvkSW7dvq0v69evHzNnzrTdjDdnzsBvv8GyZXDlStLPBw6EH34AW000IDK9iIgIoz2q79+/j6urq9nbs9uV46NHj5g1axbdunVDp9PRu3dvatasSd++fZk5cyYHDhwg4vlD+dOnT5M7d257hSpElnHnzh0OHjygT4w6nY6pU6cyd+5c6yfGmBitw02TJlClCnz1lfHE2LcvfP+9JEZhloYNGxp0KNPpdMTFxTFlyhSaNGli9vbsduU4ePBg+vXrx4kTJ6hXrx5169YlJiaG5cuXs2DBAnQ6HTqdjly5cvHw4UNee+01e4UqRJaglKJDhw48LNIS0GamWr16tfXXYHz8WBubOG0a3LiRct3u3WHuXLBlD1mRJUyZMoXGjRtz7NgxoqOjGTFiBGfOnOHBgwfs37/f7O3ZdZyjq6sr/v7+tGzZksGDB9OmTRsALl26REBAAH///TdXr16lRIkSDB8+3J6hCpHp6XQ6vvvuOzp8swUXFxdq1XqJDh1ett4Oz5+HX37Rpn57+DDlumXLwuDBMGiQJEaRJpUqVeLUqVPMnj0bR0dHIiIi6NSpE4MGDUpTJ7MMMQnA5s2bDd6XLl2a0qVLy9WiEBZWu3ZtXnrpPl6eXvp5jC3q2TOYM0dbQSO1Vd0LFICePeGtt6BaNbmNKtKtYMGCFltGMEMkR9AWO96yZQuRkZGUKVOGatWqUalSJRwdHe0dmhCZUkxMDIsWLeKdd94xGMhfIH8B6+wwKkobwL99e8r1atfW5kZ97TVIQ0cJIZLz8OFD5s+fz9mzZ9HpdFSsWJHevXvrF7YwR4ZIjpZe7FiI7C4sLIw333yTzZs3c/HiRSZPnmzdHcbFQY8eKSfGdu3gk0+gXj3rxiKypd27d9OhQwe8vLzw8/MDYMaMGUyYMIF169bRqFEjs7aXIZJj/GLHO3bswMXFBV9fXz744AMCAwPZtm0bJ57fnpHkKETqrl69Srt27fjnn38A+Pbbb+nXr5/1xi8qBUOHwvPFkA34+GgD+d99V1uQWAgrGTRoEG+88Yb+mSNAbGwsAwcOZNCgQfrfB1NliCffll7sWIjs6tChQ9SuXVt/IsiTJw/btm2z7sD+qVNhxgzDspw5tZltbt6E776TxCis7tKlS3z00UcGj+IcHR0ZNmwYly5dMnt7GSI5WnqxYyGyo6VLl9K4cWPu3r0LQLly5Th06JDZt5PMsmWLdqs0IScnbdabdu20/wthAzVq1ODs2bNJys+ePUu1atXM3l6G+Mm1xmLHQmQXSikmTpzI2LFj9WVNmjRhxYoVaeqIYLIrV7T5UBNP/7hoETRvbr39CvHcqVOn9P8fMmQIH3zwAf/++y916tQBtDspM2fO5KuvvjJ72xkiOVpjsWMhsoPIyEj69u3L4sWL9WV9+vRh1qxZSdZmtKgnT6BTp6TjF7/8UhYiFjZTrVo1dDqdwfzcI0aMSFKva9eudOnSxaxtZ4jkaK3FjoXI6mJiYjhz5gygDfKfPHkyw4cPT9PK5yaLjIReveDkScPyzp1h5Ejr7VeIRK4Ym37QQjJEcoxf7DjeG2+8wc6dO5nx/CF/rly5ZLFjIYzImTMn69evp2nTpnz99dd07NjRuju8fFkbnxgQYFheoQIsXCgD+YVNFS9e3GrbzhDJ0ZjZs2fzySefcPPmTV544QVZ01GI5+LHA8crUqQIZ86csf7E4Zs3a7PZJFqYHE9PWL1a+1cIO7p16xb79+/n7t27xCVaG3TIkCFmbcsuyfHevXvkz58/1XolSpSgRIkS1g9IiExi9uzZ/Pjjj+zevRvPBMnI6onxyhVtzcXnK+Xo5cihLTtVoYJ19y9EKhYuXMiAAQNwcXEhb968Bo8WdDpd5kiOPj4+FCxYkKpVq1KtWjX9v+XLl7fusxIhMqnY2Fg++ugjvvvuOwDeeust1q5da7vpFRcsSJoYK1SAFStkDKPIEMaMGcOYMWMYNWqUwXSJaWWX5Dh27Fj++ecfTp8+zbZt24iLi0On0+Hm5kaVKlWoWrWqPmG++OKLBn8hC5HdhIeH8+abbxos+F25cmXb/iG5cqXh+1attCtG+d0UiezZs4cpU6Zw/PhxgoKCWL16dYrPwnft2mV0vcWzZ89SwYw7Ek+ePOHNN9+0SGIEOybHeJGRkZw5c4ahQ4eyb98+AgMD+eeff/jpp5/0v/wlS5akWrVqrFixwh7hCmE3165do127dpw+fRoAJycn5syZQ58+fWwXxNmz2iuh//1PEqMwKiIigqpVq9K7d286d+5scrvz58/j5eWlf2/Ko7eE+vTpw/LlyxlpoR7Tdu+Q4+bmxvbt27l06RKHDh2iVq1aAPz999/MmDGD3377jUePHnHs2DE7RyqEbR0+fJgOHTpw584dAHLnzs3KlSvTtKp5uiS+aixUSFtZQwgjWrVqRatWrcxuV6BAAXLlypXm/U6aNIm2bduyZcsWXnjhhSTP4adNm2bW9uyeHAG+++47hg0bpk+MAFWrVmX+/Pn069ePFi1aMHfuXDtGKIRt/fHHH/Ts2ZPIyEgAypQpw8aNGylXrpztg0mcHDt1kgWJhcVVr16dyMhIKlWqxGeffWb2H4Fffvklf/75J+XLlwdI0iHHXBkiOYaGhuKazLpuderU4d133+XLL7+kZcuWNo5MCNvbuXOnwWwejRo1YuXKleTNm9f2wVy+bHywv8h2wsPDCQsL0793dXVN9rxtDl9fX+bNm0fNmjWJiori119/pVmzZuzatYuGDRuavJ1p06axYMECevXqle6YIINMPF6nTh1+/fVXgymAEipfvjwBiQcdC5FFNWrUiNdeew2A3r17s3XrVvskRkh61Zg/PzRoYJ9YhF1VqlQJb29v/WvSpEkW2W758uXp168fNWrUwN/fn1mzZtGmTRumTp1q1nZcXV2pZ8G1QjNEcpwwYQIBAQG8+uqrRqcD+vPPP/WrdQiR1Tk4OPDzzz+zYMEC5s+fb905UlOTODl27Ai2Gj4iMpTAwEBCQ0P1r1GjRlltX3Xq1OHixYtmtfnggw/4/vvvLRZDhritWrduXf0zlvLly9OmTRv9Ss7bt29n9+7ddO/e3c5RCmEdZ8+eJSwsjNoJOrnkyJFDP/G+3dy8CYcPG5bJLdVsy9PT06A3qTUFBATg6+trVpsjR46wY8cONmzYQOXKlZN0yFm1apVZ28sQyRGgY8eOnD59ms8//5xVq1axdu1aQHuQ+vrrr+vnWRUiK9m2bRuvv/46Li4uHD58mJIlS9o7pP/8/rvh+1y5wNY9ZUWm8/jxY/7991/9+ytXrnDy5Eny5MlDsWLFGDVqFLdu3eKXX34BYPr06ZQoUYLKlSsTHR3Nb7/9xsqVK1mZ+K5FKnLlykWnTp0sdhwZJjkCFCtWjHnz5jFnzhxu3LhBREQExYsXx8PDw96hCWFxc+bMYfDgwcTGxgLw6aef8nvihGQvMTEwc6ZhWYcOYM9bvCJTOHbsmEFP02HDhgHQs2dPFi1aRFBQENevX9d/Hh0dzfDhw7l16xbu7u5UrlyZjRs30rp1a7P2u3DhQsscwHM2T47Xr18nJCSEqKgocufOTalSpZJc/jo4OFh1tnUh7Ck2Npbhw4cbrDTTvn17fvzxR/sFldi6dXDtmmFZ//72iUVkKo0bN062cyXAokWLDN6PGDHC6BqM9maT5Lhjxw5++OEHdu/ezaNHjwwDcHLC39+fXr160b17d9vNFSmEHYSHh9O1a1c2bNigL/voo4+YPHlyxvrZfz6Hq56fHzxfXV2IjKhkyZIpjme8fPmyWduzanJ8+PAhPXv2ZOPGjQBG/5p49uwZe/fuZe/evUydOpWlS5dSpUoVgzpXrlzJWM9ihEiDGzdu0LZtW06dOgVofxjOmjWLfv362TmyRE6ehD17DMs++EDWahQZ2ocffmjw/tmzZwQEBLBlyxY+/vhjs7dnteT46NEj6tevz7lz51BK4enpSYsWLahWrRr58uVDKUVISAgBAQFs27aN8PBwAgMDadiwITt37qRq1aqA1pOvefPm3Lx501qhCmF1Dx89olat9gQHBwNa54EVK1bQrFkzO0dmROLObwULwhtv2CcWIUz0wQcfGC2fOXNmmqYftVpy7NmzJ2fPnsXFxYXPPvuMoUOHJtuxJiIigmnTpvHFF1/w6NEjXn/9dU6dOsXZs2dp2bIlISEh1gpTCJt48iRCnxhLly7Nhg0bzFpxwCaePYO//oIlSwzL33tPOuKITKtVq1aMGjXK7A47VkmOe/fuZf369Tg7O7NmzRpeeeWVFOt7eHjwv//9Dz8/Pzp06MClS5cYMGAA69at49GjR1SsWNEaYQphM4ULFWbs2LHs2LGDVatWkS9fPvsGFPEYgoPhndkQHg6PH8OxY3D/vmE9FxfpiCMytRUrVpAnTx6z21klOS5evBiAwYMHp5oYE2rVqhWDBw9m+vTp+unk/P39Wb9+vTXCFMJqYmNjk3SwGTt2LJ9++qn9Zrx58EAbnnHZDcIfa2UrU/lr+s03wcfH+rEJkU7Vq1c36JCjlCI4OJh79+4xa9Yss7dnleS4Z88edDod/dPwF+d7772n7+Levn17li5dKlPHiUzl/v37dOrUSZvhRvdf5zKdTmefxPjsGcyaBePHw8OH0HmMae3y5oUEa68KkZF16NDBIDk6ODiQP39+GjdunKZHGFZJjrdv38bV1TVNy+uULVsWNzc3oqKiWL16tW1XOxcinR4/fkydOnX065O2nrTOPpOGKwX//AMbNsDChWDOPJW1amlXjD16aAlSiExg3LhxFt2eVZJjdHR0upYyiW8riVFkJvfv3+fY8WPcvnQJgLx589pu7GJcHJw6BQcOaK+9eyHBLCRGubpC377g6wuenpA7NzRuDGXK2CRkISzBwcEh1Vyh0+mIiYkxa7tWSY758+fn5s2bhIaG4u3tbVbb+BnfixQpku44Zs2axZQpUwgKCqJy5cpMnz6dBiYst7N//34aNWpElSpVOJl4LTshjLh2/TqnT5/Wj+WtWrUq69evZ9z2YOvtNCwM1q6FP//UXok70yTH1xdKldSSYa9aqdcXIgNbvXp1sp8dOHCA77//PsUZe5JjleRYtWpVbt68yerVq81eeDJ+5vT4cY5ptWzZMj788ENmzZpFvXr1mDt3Lq1atSIwMJBixYol2y40NJQePXrQrFkz7ty5k64YRNYXGxvLiBEjOHUtp76sbdu2LFmyBE9PT8AKyVEpWLQIPv4YzBnm9NJL8O23cFGGZYiso0OHDknKzp07x6hRo1i/fj3dunVj4sSJZm/XKus5tmnTBqUUY8aM4cGDBya3CwkJYezYseh0Otq0aZOuGKZNm0afPn3o27cvFStWZPr06RQtWpTZs2en2K5///507doVf3//dO1fZH2PHz+mU6dOTJs2TV9WqlRJ1qxZ8zwxWlhoKOzaBY0awTvvmJYYixWDQYO0K8tDh8CCi8EKkdHcvn2bfv368eKLLxITE8PJkyf5+eefU7wgSo5VkmOvXr0oXLgwt27dolmzZgbLlyTn4sWLNGvWjJs3b+Lr65uuteyio6M5fvw4LVq0MChv0aIFBw4cSLbdwoULuXTpEmNN7KEXFRVFWFiY/hUeHp7mmEXm88Ybb7Bu3TpAm1ntxRdeoHKlypZ7zhgbC9u2QffuULz4f0tG7d2bfJtSpbT6s2bB6dNw9Sr88AO0aAEOGWJtcyEsLjQ0lE8++YQyZcpw5swZtm/fzvr165NMRWoOq9xWdXV1ZcGCBbRp04ZTp07x4osv0rVrVzp16kT16tX1vfdCQkI4ceIEK1euZOnSpURGRuLk5MT8+fPT1aHn/v37xMbG4pNofJaPj49+lpLELl68yMiRI9m7dy9OTqZ9WSZNmsT48ePTHKfI3MaNG8fOnTtxdXWldu065LfUwP6nT2HqVJg3T1twODUtWsCrr0LLliBzEIts5uuvv2by5MkULFiQ33//3eht1rSw2vRxzZs357fffqNPnz5ERESwcOHCFKfvUUrh7u7OTz/9RMuWLS0SQ+IeTEopo72aYmNj6dq1K+PHjzdr+MmoUaP0a5UB3Lp1i0qVKqU9YJGp1KpVi+XLl1O6dGmmHn5smY2Gh0Pr1rBvX+p1S5TQBvWbue6dEFnJyJEjcXd3p0yZMvz888/8/PPPRuvF92cxlVVX5XjjjTeoWrUqn376KWvXriUuLs5oPQcHB1599VUmTpxokani8uXLh6OjY5KrxLt37ya5mgRtGaFjx44REBDA4MGDAYiLi0MphZOTE1u3bqVp06ZJ2rm6uhpc4YaFhaU7dpExKSAoKCjJzDdt27bV/nP4aPp3EhoKrVrBwYPJ13FyggoVtInAP/oIcuRI/36FyMR69OhhlWF/Vl/PsXz58qxcuZLg4GB27drFmTNn9BOJ582bl0qVKtGkSRMKFixosX26uLhQs2ZNtm3bxquvvqov37Ztm9FLbi8vL06fPm1QNmvWLHbs2MGKFStkuaxsLi4ujlOnT3Pjxg1GjNjNN998k74NRkVpifDxY+1KMShIezY4f742v2li1atDz57a88YKFWQScCESSLx4sqXYZLFjgIIFC/Lmm2/aancMGzaM7t274+fnh7+/P/PmzeP69esMGDAA0G6J3rp1i19++QUHB4ckD24LFCiAm5tbuh7oiswvJCSEQ4cOEfK81/W0adPo3r071apVM30j9+7ClavwVXe4cwcSLfidrPz5tXGM0nNaCJuzWXK0tS5duhASEsKECRMICgqiSpUqbNq0ieLFiwPaLbLrqc0gIrK1Cxcu0KZNG0KrdgXA0cGBP/74w/TEqBT8+y+cO6e9P3/e9J37+MCOHSDPsIWwiyybHAEGDhzIwIEDjX6W2qX4uHHjLD5Xn8g8du7cSefOnXn48CH5q4KrqwsvvVSL119vbtoG4uJg+HC4nobxjoUKaYmxfHnz2wohLCJLJ0ch0mL+/PkMGDBAPxejl6cntWrVwt3d3bQNxMVBnz7aLDaprYCh00GePFrP0xIloGZNGDBAm9pNCGE3khyFeC42NpZRo0YxZcoUfVmbNm3IW6+eyWNfAZgxQ0uMiY0bp81u4+OjrXaRMye4u2sJUgiRociUGUI8FxUVxfbt2/XvP/zwQ9auXWteYnzyBEaPNizTAdWraWsjNm4MFStCgQLaMAxJjEJkSJIchXguR44crFu3juLFizN79my+/fZb86eCO31KS5AJ+b0EhdO/yowQwnbktqrI1uLi4nBIMOdo4cKFOXv2rOnPFxO6eRPuJVo2qnhx7TaqECJTkStHkW2tXr0af3//JDMbpSkxRkXBmTOGZUWKaLdQhRCZjiRHke0opfj666/p3LkzR44coUuXLmavEp7E2bPw7Jlh2ezZ2nRvQohMR5KjyFaio6Pp27cvn3zyiX518Lx58xIbG5v2jR44kHT1jDffhPh5V4UQmY4kR5FtPHjwgFdeeYUFCxboyyZMmMCvv/6a9iXSYmNhyBDDMi8vmD497YEKIexO7vmIbOHixYu0bduWCxcuANqKKj///DNdunRJ34YXLoTjx6FEm//Kxo+XTjhCZHKSHEWWt2vXLjp16sTDhw8BbVL5tWvXUqdOnfRt+M4dGDXKsCxnThg0KH3bFULYndxWFVnaiRMnaNGihT4xVqlShSNHjqQvMT56BP/7H5QpA/cTDd2oUhmcndO+bSEyuT179tCuXTsKFSqETqdjzZo1qbbZvXs3NWvWxM3NjVKlSjFnzhzrB5oKSY4iS6tWrZp+Tc9WrVqxf/9+/cosZnn8GK5cgTZtoHBh+PxzrSyhggUhX34LRC1E5hUREUHVqlX54YcfTKp/5coVWrduTYMGDQgICODTTz9lyJAhrFy50sqRpkxuq4oszcHBgUWLFlG7dm2GDBli+lRw16/D6tWweze41YToaK180ybj9V1dobIsLyVEq1ataNWqlcn158yZQ7FixZj+vBNbxYoVOXbsGFOnTqVz585WijJ1khxFlhIZGcnTyEhy58qlL3N3d2fYsGGmNIZ582DpUjh48L/yzi8k30ang27doG59bRJxIbKo8PBwgwkzXF1d097LO4GDBw/SokULg7KWLVsyf/58nj17hrOdHlNIcrSyPouOpqtOws/m93op1XJLxZHcvhIyZb/mxmBqPWP7DggIYO++fcTFxVK/fn3z4n74kD4fzYewcCjUnPkcTFoH6JNwCSpfXyhfDnIartlo6nGay9yfBXPjMOXrld6fhfS0N+VnPj2/F9aonxbmfo0s9TVNTaVEC2+PHTvWImveBgcH45Ood7ePjw8xMTHcv38fX1/fdO8jLSQ5iixh7dq1dO3aFY9WwwH45/Q/1K5d27TGz57BG2+Ad92U67m5Qf58kL+A9q+zSzqjFiLzCAwMpHDhwvr3lrhqjKdLtDpN/AQdicttSZKjyNSUUnzzzTeMGDECpRQeQO7cuahWrZrpGxk6FP76CzonSo65c0P79lCmmrYgcY4cFoxciMzF09MTLy8vi2+3YMGCBAcHG5TdvXsXJycn8ubNa/H9mUqSo8i0oqOjGTRoED/99JO+rHDhQlStWg1HBxM7Ys+eDTNnGpa5usCGDdC8Obi4gJVukwohwN/fn/Xr1xuUbd26FT8/P7s9bwQZyiEyqYcPH/LKK68YJMZx48ZRvXoN0xPjihXw/vuGZQ4O8NJL2pANF7ltKoS5Hj9+zMmTJzl58iSgDdU4efIk169fB2DUqFH06NFDX3/AgAFcu3aNYcOGcfbsWRYsWMD8+fMZPny4PcLXk+QoMp2IiAjq1KnDzp07Ae3Zx5IlSxg7diwmP6FYuxbeekubGzWhqlUhV26LxitEdnLs2DGqV69O9erVARg2bBjVq1dnzBitM1tQUJA+UQKULFmSTZs2sWvXLqpVq8bEiROZMWOGXYdxgNxWFZlQaFiYfo7U/Pnzs2bNGurWTaUzTUKbNsHrr0PiZarKltEG+Ash0qxx48b6DjXGLFq0KElZo0aNOHHihBWjMp9cOYpMp5CvLxMmTKBSpUocPnzY9MQYGwOBgVonm8RrL773HpSvYPlghRCZkiRHkeEZ+xv0s88+48iRI5QsWdK0jdwJhl274PLlpLdS+/YFE6e6EkJkD3JbVWRosbGxBJwMoED+AhQrVkxfrtPp8PDwSH0D4WFwJjDpBOHxevaEuXO1jjhCCPGcJEeRYUVGRnLk6FFCQ0MJDr5Djhw5yJcvn2mNnz2Dc2fh2nXjn7u4wOjR2ksSoxAiEUmOIkMKDQvj6JEjPI2MBMDR0YE4FWda4+AgOP0PREUZ/7xpU218Y7lyFopWCJHVSHIUGc6dO3c4ceIEMc+fDbq7u1Or1kt4eaYyO0dwMBw/BkHBxj93c4OKFeHTcdqE4UIIkQy5nyQyDAVcunyZo0eP6hNj7ly5aFC/fsqJUSn49VeoVMl4YnR01K4SmzTRhmpIYhRCpEKuHEWGEKfi+Of0P1xLMDi4UKFCVKtWFUcHR+ONoqNhxw6YMQM2bzZep0ABeOEFWU5KCGEWSY4iQ/j75N/cvHVL/75cubKUK1cOnbE5b0IfQffusH49hIYa36CLM1SuIoP6hRBpIslRZAglS5UiKDgIpRRVq1ajiLGk9ugRXLgAd+/Cyt+S31ihQlClisyNKoRIM0mOIkPI5e1NjRo1cXFxJk/uPP99oBTcvQOXr0BISMobKVgQ/Py0f4UQIh0kOQq7uHf/Hvny5vtvMdOYZxR0dID7IXDlijbvaWwcPHkCT5+mvLE6daBzZ22mmzUXrR+8ECLLk+QobEqhOH/+PBcv/kupkiWpXK4cBARot0rNkS8ffPSR9uxRnisKISxMkqOwmdjYWE6ePMntoCAALl+5QsFHD8n78JHpG3FxgdKl4eerYMr0cUIIkQaSHIVNBAcHc+DgAR490nqX6oBKPgXIc8fEK0ZvbyhZUuts4+AgiVEIYVWSHIXVnTp1irZt2xJZqzcATo6O1ChXFp9z5wwr6nSQy1tbbNjNDRwdtAH8Xl7gncv2gQshsi1Jjlbw5MkTIiIiAHgWlUpnEjPEbzPxdhOWJye5OEzZpiltk7NlyxZ69uxJREQE+WpE4+buht8LL+D59988exZtWLlWLcib1/iGEsWQ3L5N+Xqb0taU4zeXKV+vlJgSn7lxm/t9Ts/PQnrbm/Izn57fC2vUTwtzv0aWqp+cJ0+emFU/q9CplJZsFma5efMmRYsWtXcYQghhcTdu3KBIkSL2DsNmZG5VIYQQIhG5rWoF58+fp/Dz4QXv/XbcYtud/XZN/f8TbjdheXKSi8OUbZrS1pjg4GAaNWpE165d+d///segJc+HbBxPtL3Gjc2e+zS5fZvy9TalrSnHby5Tvk8pMSU+c+M29/uc1p8FS7Q35Wc+Pb8X1qifFuZ+jSxVPzmfNSlI+fLlzWqTFWTp5Dhr1iymTJlCUFAQlStXZvr06TRo0MBo3VWrVjF79mxOnjxJVFQUlStXZty4cbRs2dLs/ebIkUO/Sr2zq+UmvPZI0EMz4XY9TOi5mVwcpmzTlLYASqn/BvUDpUuX5syZM3h7e/+3nfsPwCnBtG558kCuPJgruWM25ettSltTjt9cpnyfUmJKfObGbe732dSfheSkp70pP/Pp+b2wRv20MPdrZKn6ycmRI4dZ9bOKLHtbddmyZXz44YeMHj2agIAAGjRoQKtWrbh+3fjK8Hv27KF58+Zs2rSJ48eP06RJE9q1a0dAQICNI8+c9u/fT5MmTQhNNBF4fGIEIC4O7iRaUqqQrw2iE0II82TZ5Dht2jT69OlD3759qVixItOnT6do0aLMnj3baP3p06czYsQIXnrpJcqWLcuXX35J2bJlWb9+vY0jz3wWL15M06ZN2b17N2+88QYxMTHGK969CzGxhmW+khyFEBlPlkyO0dHRHD9+nBYtWhiUt2jRggMHDpi0jbi4OMLDw8mTJ/lbflFRUYSFhelf4eHh6Yo7s4mLi2PMmDG8/fbbREdH68ueJjcXatBtw/d584Crm5WjFEII82XJ5Hj//n1iY2Px8fExKPfx8SE42MhK8UZ88803RERE8MYbbyRbZ9KkSXh7e+tflSpVSlfcmUlsXCxvvfUWEydO1Jf179+fTZs24enpmbTB06cQfMewrJDMiSqEyJiyZHKMl7BzCCTtMJKc33//nXHjxrFs2TIKFCiQbL1Ro0YRGhqqfwUGBqY75swgKiqKgwcO8scffwDa1/nbb79l9uzZODs7G2+0YQPEJrqlKktLCSEyqCzZWzVfvnw4OjomuUq8e/dukqvJxJYtW0afPn1Yvnw5L7/8cop1XV1dcXV11b8PCwtLe9CZRFh4GEeOHNXfOvXw8GDp0qW0bdvWeIM9e+CHH2D1aujw6X/l+fJCgq+dEEJkJFnyytHFxYWaNWuybds2g/Jt27ZRt27dZNv9/vvv9OrViyVLltCmTRtrh5npPI6IYP/+/frEWKRIEfbv3288MUZGQq9e0KgRLF+urc+YUKFC1g9YCCHSKEteOQIMGzaM7t274+fnh7+/P/PmzeP69esMGDAA0G6J3rp1i19++QXQEmOPHj347rvvqFOnjv6q093d3XA4Qjbm4eGBj48Pt27dJlcub3YfOYKvsd6mt27Bq6/C0aPGN+TqIslRCJGhZdnk2KVLF0JCQpgwYQJBQUFUqVKFTZs2Ubx4cQCCgoIMxjzOnTuXmJgYBg0axKBBg/TlPXv2ZNGiRbYOP0PSAVWrVsPDw4MypcsYT4xHj0KHDvB8zUYDjg5QuAiULQtOyTybFEKIDCDLJkeAgQMHMnDgQKOfJU54u3btsn5AmUxoaCiXLl0yKHN0cKB8uWSmkrp2DV55BR48MCzPmRMmTgSPWpBchx0hhMhAsuQzR5F+V65coW7dujRv3ty0pXmiouC115ImxtKl4dAh+PBDSYxCZCOzZs2iZMmSuLm5UbNmTfbu3Zts3V27dqHT6ZK8ziVe89WGJDmKJB48fEjt2rUJDAzkwYMHBJw8Sarrmg0dCseOGZY1bgxHjkDlylaKVAiREZk7fWe88+fPExQUpH+VLVvWRhEnJclRGLh16xYHDx7k3r17AJQrV47q1aqR4ujQxYsh8bR8ZcrAmjXaxOJCiGzF3Ok74xUoUICCBQvqX46OjjaKOClJjgLQJkg4f+E8JwICiIuLA6Bp06YcOnQo5dUHLl6E/v0Ny9zdYeVKkF6+QmQZ4eHhBtNlRkVFGa2Xnuk7q1evjq+vL82aNWPnzp0Wiz0tJDkKIiMj6dq1KxcuXNSX9evXjy1btpA7d+7kGz57Bm+/DYmfSc6ZAy++aKVohRD2UKlSJYPpMidNmmS0Xlqm7/T19WXevHmsXLmSVatWUb58eZo1a8aePXssfhymytK9VUXq7ty5Q8eOHTl06BD5O49BB1SsVIm548elPtXexInaM8WE+vWDHj2sFq8Qwj4CAwP1i7gDBrODGWPO9J3ly5c3WFDZ39+fGzduMHXqVBo2bJiOqNNOrhyzuUOHDnHo0CEAHB0d8XvJj9KlSqWeGB8+hC++MCwrXx6mT7dOoEIIu/L09MTLy0v/Si45pmf6zoTq1KnDxYsXU69oJZIcs7kOHTrwxRdfULhwYerVq0tBn1QmA1dxcP0aHDuqLV4cz8kJfvsNsumq4UIITVqn70wsICDA+EQjNiK3VQWjRo1iwIABfLzOcMA/SsHff8P169o4xqgobcHiJ0+SbmT8ePDzs03AQogMzdzpO6dPn06JEiWoXLky0dHR/Pbbb6xcuZKVK1fa7RgkOWYjcUoReOYMnp6e+mn0QHs2oC3q/Dw5PnwIAwdqy0zduAGdx6S84Xr14JNPrBe4ECJTMXf6zujoaIYPH86tW7dwd3encuXKbNy4kdatW9vrECQ5ZhfPYmI4cfw4d+/dQ6eDHB4e5M+XL2nFWzch4CSsTHk8kt7LL8OSJWDH8UhCiIzHnOk7R4wYwYgRI2wQlekkOWYDV69eZf/+fYSHPwZAh46oqMikFWOewRkTF2zOnRv++guaNgUTFpAWQojMRJJjFnfw4EE6duyIaqDd63dxdsbPz4+8efMmrfzvvxAdnbTc3R28PLXFiV1dIW8+yJcPmr1k5eiFEMI+JDlmYUuXLqVXr15ERUWRH209xtq1ahmf8ebqVbh82bCsWTP47js4aqQDjhBCZGEylCMLUkoxYcIE3nrrLf0UT/ny5qV+/frJTwU3ahTEJZhe3MkJZs2SScOFENmSJMcsaPjw4YwdO1b/vk+fPtSuXRuX5JaMOnwYli41LBs4EMqVs2KUQgiRcUlyzILefvttcuTIgU6n4+uvv+bHH3/EwSGZb7VS8PHHhmXOTjAmleEbQgiRhckzxyyoevXqLF26lNjYWDp27Jhy5a1bIfEipGXLgbEOO0IIkU1IcswCjhw5Qo0aNXBy+u/b2a5dO9Maf/aZ4Xt3dyhRwnLBCSFEJiS3VTO5q9euUbduXYYNG2Z+4zvBcOyYYVm5cpDcLVghhMgm5CyYSSml+OfMGU6fPk1sbCzff/89GzZsMGcLcO68YZGHBxQpYtE4hRAiM5LbqplQeHg4R44e5e7du/qyESNGmDcP4e0gCA83LCtfTma7EUII5Mox07l27Rr16tXTJ0adTsdPP/3E5MmTk++RmlhMDJw7a1hWpQoUKmThaIUQInOS5JiJHD58mNq1a3P69GkAnJ2dqVOnNn369DFvQ4GB8OSpYdmECYBcNQohBEhyzDRu375N48aNuXPnDgAeHjmoX78++fIaWVkjJXfuaOszJlS/PqQ25EMIIbIReeaYCSiluHzlMpGR2koajRo1omj9+rg4u5i3oehoOPW3YZmHB/z8szxrFEKIBOTKMRPQ6XS85PcSxYoVo1evXmzdutX0xKgUnDoFZ8/Cnj0QlWjVjW+/hVKlLB+0EEJkYnLlmEm4urpy9OhR8ufPjy61q7wHD2DbNu21dSvcuAGdjUwH51MA+va1TsBCCJGJSXLMgMIfPyYw8Aw1qtfAOcFk4QUKFDCs+OwZhD6C5cshLEx7lrh1Kxw5AnFxKe/ExRlerCq3U4UQwghJjhnMvfv3OH7sOM9iYjh2/Di1a9fCQZfo7ndAAPx9Em7d1pLgxxPM24m3N1Srpi1cLIQQIgl55piBXL12jcOHD/MsJgaAZ9HRPHsW81+FI0egcWOoUQNu3Ez96jAhdzcoXRoaNoQGDcDT07LBCyFEFiJXjhmAUorAwEAuX7miLyvo40P1GtVxcnCAiAi4cAF69zd9o+7uWiJt0UJ7HYmwfOBCCJFFSXK0s5iYGE4EnODOnf+mgivt5UnFyEh0f23XniumRKeD8uW1K0Fvb3jxRWjVSrs6dHP7r96Ro1Y6AiGEyHokOdrR06dPOXLoIGERTwBtfpoXgWJh4Sm2A7TnhSVKQPFisHycFaMUQojsR5KjnUTeuMHeU6eIUgoAZ8APSHW+Gy8vGDMGcteXpaWEEMJK5OxqSzHPtDGHe/fg+vff5H+eGD2A+qSSGJ0c4b334N9/4aOPJDEKIYQVyZWj1Sm4c1dLinfvQJyWEHVAVcAFKPv8X0B7Tpg7N+TKpV0lurlqt1CdXaB3LXscgBBCZDuSHK0lKgoWL4Y9IfD4MXHAY8ArQRUHoDJADncoVBh8fbVONUIIIexK7s1Zw19/Qbly0KcPPH5MNHAQOICWIPVyekD1atCkKVSoIIlRCCEyCLlytIbevfX/fQwcAeJHGR4HGvr4oCtSBAoWlOnbhBAiA5LkaEXbgX1A/EhFVycnqvr5octn5hqMQgghbCpL31adNWsWJUuWxM3NjZo1a7J3794U6+/evZuaNWvi5uZGqVKlmDNnTpr3PQ9oyX+J0cvLiwaNG5FLEqMQIhuw5/nXErJscly2bBkffvgho0ePJiAggAYNGtCqVSuuX79utP6VK1do3bo1DRo0ICAggE8//ZQhQ4awcuVKs/c9AegPxD5/7+NTgHp16+Lu5p7m4xFCiMzCnudfS8myyXHatGn06dOHvn37UrFiRaZPn07RokWZPXu20fpz5syhWLFiTJ8+nYoVK9K3b1/eeecdpk6dava+f0zw/1KlSvKS30s4OckdbCFE9mDP86+lZMnkGB0dzfHjx2nRooVBeYsWLThw4IDRNgcPHkxSv2XLlhw7doxnycxvGhUVRVhYmP4VHv7ftG+Ojo7MmTOHypUqp744sRBCZBG2Ov9aW5a8nLl//z6xsbH4+PgYlPv4+BAcHGy0TXBwsNH6MTEx3L9/H19f3yRtJk2axPjx45OUe3h4MG/ePBo2bMjO1efScSSGbt68qf9/RHio0fLkJKxv7jZNaWuK5LaTFsnt25R9mNLWlOM3l7lfr8RMic/cuM39Pqf3ZyE97U35mU/P74U16qeFuV8jS9VPTlCQ9m9oaCheXv+N1HZ1dcXVyJqwtjr/Wp3Kgm7duqUAdeDAAYPyzz//XJUvX95om7Jly6ovv/zSoGzfvn0KUEFBQUbbREZGqtDQUP3rzz//VIC85CUveWX519ixY+16/rW2LHnlmC9fPhwdHZP8lXL37t0kf53EK1iwoNH6Tk5O5M2b12ibxH85+fn5AfDPP//gnY0G9IeHh1OpUiUCAwPxzEaLKMtxy3FnB6GhoVSpUoUrV66QJ08efbmxq0aw3fnX2rJkcnRxcaFmzZps27aNV199VV++bds2OnToYLSNv78/69evNyjbunUrfn5+ODs7m7Tf+E43RYsWNbj9kNWFhYUBULhwYTnubECOO3sdd/yx5smTx6Tjttf51+Lscr1qA0uXLlXOzs5q/vz5KjAwUH344YfKw8NDXb16VSml1MiRI1X37t319S9fvqxy5Mihhg4dqgIDA9X8+fOVs7OzWrFihcn7DA0NVYAKDQ21+PFkZHLcctzZgRy36cdtj/OvpWXJK0eALl26EBISwoQJEwgKCqJKlSps2rSJ4sWLAxAUFGQw5qZkyZJs2rSJoUOHMnPmTAoVKsSMGTPo3LmzvQ5BCCEypSxx/rVbWs6CIiMj1dixY1VkZKS9Q7EpOW457uxAjjt7HbdOqecr7gohhBACyKKTAAghhBDpIclRCCGESESSoxBCCJGIJEchhBAiEUmOZsrsa5SllTnHvWrVKpo3b07+/Pnx8vLC39+fP//804bRWo653+94+/fvx8nJiWrVqlk3QCsx97ijoqIYPXo0xYsXx9XVldKlS7NgwQIbRWs55h734sWLqVq1Kjly5MDX15fevXsTEhJio2jTb8+ePbRr145ChQqh0+lYs2ZNqm2yyjktVfbuLpuZxA9s/fHHH1VgYKD64IMPlIeHh7p27ZrR+vEDWz/44AMVGBiofvzxR7sPbE0Lc4/7gw8+UJMnT1ZHjhxRFy5cUKNGjVLOzs7qxIkTNo48fcw97niPHj1SpUqVUi1atFBVq1a1TbAWlJbjbt++vapdu7batm2bunLlijp8+LDav3+/DaNOP3OPe+/evcrBwUF999136vLly2rv3r2qcuXKqmPHjjaOPO02bdqkRo8erVauXKkAtXr16hTrZ5VzmikkOZqhVq1aasCAAQZlFSpUUCNHjjRaf8SIEapChQoGZf3791d16tSxWozWYO5xG1OpUiU1fvx4S4dmVWk97i5duqjPPvtMjR07NlMmR3OPe/Pmzcrb21uFhITYIjyrMfe4p0yZokqVKmVQNmPGDFWkSBGrxWhNpiTHrHJOM4XcVjVRVlmjzFxpOe7E4uLiCA8PN5i0OKNL63EvXLiQS5cuMXbsWGuHaBVpOe5169bh5+fH119/TeHChSlXrhzDhw/n6dOntgjZItJy3HXr1uXmzZts2rQJpRR37txhxYoVtGnTxhYh20VWOKeZKstOH2dpWWaNMjOl5bgT++abb4iIiOCNN96wRohWkZbjvnjxIiNHjmTv3r36Segzm7Qc9+XLl9m3bx9ubm6sXr2a+/fvM3DgQB48eJBpnjum5bjr1q3L4sWL6dKlC5GRkcTExNC+fXu+//57W4RsF1nhnGYquXI0k06nM3ivlEpSllp9Y+UZnbnHHe/3339n3LhxLFu2jAIFClgrPKsx9bhjY2Pp2rUr48ePp1y5crYKz2rM+X7HxcWh0+lYvHgxtWrVonXr1kybNo1FixZlqqtHMO+4AwMDGTJkCGPGjOH48eNs2bKFK1euMGDAAFuEajdZ5ZyWmsz5560dZJU1ysyVluOOt2zZMvr06cPy5ct5+eWXrRmmxZl73OHh4Rw7doyAgAAGDx4MaElDKYWTkxNbt26ladOmNok9PdLy/fb19aVw4cIGa5hWrFgRpRQ3b96kbNmyVo3ZEtJy3JMmTaJevXp8/PHHALz44ot4eHjQoEEDPv/88yx1FRUvK5zTTCVXjiZKuEZZQtu2baNu3bpG2/j7+yepb/c1ysyUluMG7YqxV69eLFmyJFM+gzH3uL28vDh9+jQnT57UvwYMGED58uU5efIktWvXtlXo6ZKW73e9evW4ffs2jx8/1pdduHABBwcHihQpYtV4LSUtx/3kyRMcHAxPoY6OjsB/V1NZTVY4p5nMTh2BMqWssEZZWph73EuWLFFOTk5q5syZKigoSP969OiRvQ4hTcw97sQya29Vc487PDxcFSlSRL322mvqzJkzavfu3aps2bKqb9++9jqENDH3uBcuXKicnJzUrFmz1KVLl9S+ffuUn5+fqlWrlr0OwWzh4eEqICBABQQEKEBNmzZNBQQE6IevZNVzmikkOZpp5syZqnjx4srFxUXVqFFD7d69W/9Zz549VaNGjQzq79q1S1WvXl25uLioEiVKqNmzZ9s4Yssw57gbNWqkgCSvnj172j7wdDL3+51QZk2OSpl/3GfPnlUvv/yycnd3V0WKFFHDhg1TT548sXHU6Wfucc+YMUNVqlRJubu7K19fX9WtWzd18+ZNG0eddjt37kzxdzUrn9NSI0tWCSGEEInIM0chhBAiEUmOQgghRCKSHIUQQohEJDkKIYQQiUhyFEIIIRKR5CiEEEIkIslRCCGESESSoxBCCJGIJEchhBAiEUmOQgghRCKSHIUQQohEJDkKIYQQichixxYUFxfH7du38fT0zHKrYgshsielFOHh4RQqVCjJ+pVZmSRHC7p9+zZFixa1dxhCCGFxN27cyDSLV1uCJEcL8vT0BLQfIi8vLztHI4QQ6RcWFkbRokX157fsIksnx1mzZjFlyhSCgoKoXLky06dPp0GDBkbrBgUF8dFHH3H8+HEuXrzIkCFDmD59uln7i7+V6uXlJclRCJGlZLdHRVn2BvKyZcv48MMPGT16NAEBATRo0IBWrVpx/fp1o/WjoqLInz8/o0ePpmrVqjaOVgghREaiU0opewdhDbVr16ZGjRrMnj1bX1axYkU6duzIpEmTUmzbuHFjqlWrZvaVY1hYGN7e3oSGhsqVoxAiS8iu57UseeUYHR3N8ePHadGihUF5ixYtOHDggMX2ExUVRVhYmMFLCCFE5pclk+P9+/eJjY3Fx8fHoNzHx4fg4GCL7WfSpEl4e3vrX9JTVQghsoYsmRzjJX6ArJSy6EPlUaNGERoaqn/duHHDYtsWQghhP1myt2q+fPlwdHRMcpV49+7dJFeT6eHq6oqrq6vFtieEECJjyJJXji4uLtSsWZNt27YZlG/bto26devaKSohhBCZRZa8cgQYNmwY3bt3x8/PD39/f+bNm8f169cZMGAAoN0SvXXrFr/88ou+zcmTJwF4/Pgx9+7d4+TJk7i4uFCpUiV7HIIQQgg7ybLJsUuXLoSEhDBhwgSCgoKoUqUKmzZtonjx4oA26D/xmMfq1avr/3/8+HGWLFlC8eLFuXr1qi1DF0JkRxERcOwY3LmjvWJioGNHKFnS3pFlS1l2nKM9ZNfxQEKIdJo/H4YPh0ePDMtz5IDly6F1a7uEBdn3vJYlnzkKIUSmoBSMGwd9+yZNjABPnkD79rBwoa0jy/ay7G1VIYTIcNauhS++0JJemTLardONG1NuExsL77wDt2/Dp59CNpvj1F4kOQohhLVFR8OIEfDdd/+VnTljvG6ZMuDqmvTzzz6D69dh5kxwklO3tcltVSGEsKZr16BBA8PEaIxOpyW+ixfh1CktmSY2bx60awfh4daJVehJchRCCEv45huoVQveew9u3tTK9u4FPz84ciTltm5usHIlDByovXdwgMmTtYSa+Dbqli3QsCFcumT5YxB60lvVgrJrry4hsr2NG6Ft2//e58wJb7+t9UJ99sywrqsrfPKJdqv1wgVwcYGPP4YaNYxve+VKbVuRkYblOXPCDz9Ajx5WfQ6ZXc9rcuNaCCHSa/Fiw/ePH8OcOUnrlSmjDc2oVs30bXfuDIUKab1W79833EevXrB5M3z7Lfj6piVykQy5rSqEEOkRFweJpqo0qnVrbZC/OYkxnr8/HDwI5csn/WzZMihbFsaP1xKmsAhJjkIIkR4nThhe0Rnz0Uewbh14e6d9P2XKaMn1nXeSfhYRoY2XLF5cu9L87jsIDEz7voQkRyGESJc//zR8X7gwVKmi/d/bW3vuOHUqODqmf185c2rb++MPyJUr6ecPHsCqVfDhh1C5MnTrZnxyAZEqSY5CCJEeW7cavu/USRuKcfGiNnDf2JVeer3+unZl2KeP1rM1OUuWQNWqsHu35WPI4iQ5CiFEWoWFwYEDhmUtW2q9R8uU0eZGtRZfX/jpJzh5Elq1Sr7e9evQpAmMHq3NyCNMIslRCCHSaudOw4Tj7AyNG9s2hhdegE2b4MoVWLRIu5pMfMtVKfjySy1Jxo/BFCmyWHK8fv06AQEBHDp0iPPnz/Ms8dgeIYTIahI/b6xfHzw87BNLiRLQs6d2NXnqlJYIE9u3T+stu3ixXEWmIl3JcceOHXTq1Im8efNSsmRJ/Pz8qFevHpUqVSJnzpw0btyYRYsWERsba6l4hRAi40j8vLFlS/vEkVjRovDXX/D119rVbEIhIdqkAmXLwowZWk9XkUSaZsh5+PAhPXv2ZOPz2eST24Tu+awNFStWZOnSpVSJ78H13JUrVyiZhRbyzK4zSQiRLV26pD1XTCggIG3jGK3pyBHo0gWSW7S9TBltSrrSpY1+nF3Pa2bPkPPo0SPq16/PuXPnUErh6elJixYtqFatGvny5UMpRUhICAEBAWzbto3w8HACAwNp2LAhO3fupGrVqgCcPXuW5s2bc1PufwshMqPEt1R9fODFF+0TS0pq1dKS9jvvwOrVST//919trtbt26FCBdvHl1EpM7Vv317pdDrl6uqqJk6cqB4/fpxs3cePH6sJEyYoV1dXpdPpVNmyZdXTp0/ViRMnVP78+ZWDg4O5u8/QQkNDFaBCQ0PtHYoQwtrat1dK6+qivd5+294RpSwuTqlVq5SqXdsw7vhX/vxKnTyZpFl2Pa+Z9cxx7969rF+/HmdnZ9asWcNnn32GRwoPnz08PPjf//7H6tWrcXJy4tKlSwwYMIBmzZpx//59KshfKUKIzCg6GnbsMCzLKM8bk6PTwauvatPQ7dmjjX9M6N49rRPP0aP2iS+DMSs5Ln4+ue7gwYN55ZVXTG7XqlUrBg8ejFKKX3/9lUePHuHv78/evXvNizazaNIERo3S5luMirJ3NEIISzt0KOk8pi1a2CcWc+l02vqSO3dC7dqGnz18CC+/nHTsZjZkVnLcs2cPOp2O/v37m72j9957T///9u3bs337dvLkyWP2djKFEyfgq6+0X5bixWHKFFmcVIisJPHzxurVoUAB+8SSVrlza3/AN2pkWB4Wpp27svmsOmYlx9u3b+Pq6kq5cuXM3lHZsmVxc3MDYPXq1fr/W9OsWbMoWbIkbm5u1KxZM9Ur1d27d1OzZk3c3NwoVaoUc4wtOWOuO3e0Fb2LF4eJE+Hp0/RvUwhhX4mTY2a5akzM01ObQCBx/BER2qw7mzbZJ64MwKzkGB0djaura5p35urqiqurq36IhzUtW7aMDz/8kNGjRxMQEECDBg1o1aoV169fN1r/ypUrtG7dmgYNGhAQEMCnn37KkCFDWLlypWUCevgQxozRJiRO/IslhMg87t3T7g4llNGfN6YkRw5YuxbatDEsf/pUW0Py11/tE5e9mdN7p1ixYsrBwUE9evTI7J4/jx49UjqdThUtWtTstmlRq1YtNWDAAIOyChUqqJEjRxqtP2LECFWhQgWDsv79+6s6deqYvE99r66PPlLqpZeM9wiLf3XurNSxY+YfmBDCvhYvNvxd9vBQKirK3lGlX1SUUq++muRcFQrZsreqWeMcq1atys2bN1m9ejW9evUyKwmvWrVKvw1ri46O5vjx44wcOdKgvEWLFhxI5kHzwYMHaZHo1kLLli2ZP38+z549wznxLBNAVFQUUQk63ISFhQFQYckSHBwctGcQYWEQGZmkbY2VK1m3ciXUq6ctL9OpE+07duRE4r9IjRg2bBjDhg3Tvw8PD6dixYqptgNYu3YtNWvW1L/fsGEDAwYMSLVdzpw5OXfunEHZxx9/zO+//55q2zZt2jB37lyDMj8/P4KDg1Nt+/XXX9O1a1f9+/Pnz9OsWbNU2wEcPXoU3wSro8+bN48JEyak2q5cuXLsSNQTsVu3buw24RlMv379GDt2rEFZkSJFTIr3t99+o3GCeTl37drF22+/bVLbxOOFx48fz48//phqu0aNGuk72sVr2rQpFy5cSLXtmDFjePfdd/Xvg4KCeOmll0yKd/v27ZRPsHDvkiVLGDFiRKrtChYsyLFjxwzK+vfvr5+QJCVvvfUWU6ZMMSirUKECj01YIHjOnDm0bdtWe7N1K8eBDvEfxsZCqVLJtj179iyenp7699OmTWPatGmp7rNGjRqsW7fOoKx9+/bWP0e0bk3NBLdTt5jUKusxKzm2adOGDRs2MGbMGNq3b29yh5qQkBDGjh2LTqejTeJLdyu4f/8+sbGx+Pj4GJT7+Pgke0IODg42Wj8mJob79+8bnGTjTZo0ifHjxycpDwoKSjXGovH/2b9fezVsyL2wMG7dupVq2/gkHE8pZVI70P5wSOjp06cmtU34yx3v4cOHJrV98OBBkrLg4GCT2j558sTgfUxMjMnHmnjawsePH5vU1tvIgrT37983qW1oaGiSMlPjjUrUszkqKsrktsbiMKXtfSOL9N65c8ektomTSmxsrMnxxiSa1/PJkydpPtYHDx6Y1Pbhw4dJym7fvk24CZ3lnsb3FVAKtm4lGtDvMTISUti/SjSDWJiJv+dFixZNUnbv3j3rnyP++EObzOCrrwDIrr0kzEqOvXr14vPPP+fWrVs0a9aM5cuXUybx9EmJXLx4kddff52bN29SqFAhevfuna6AzZH42aZSKsXnncbqGyuPN2rUKIO/zsLCwihatCi+vr7alWNiT55oC48qRf7En+3ZQ34HBwp7eWkPyVOQeAonnU5H4cKFU2wTz8XFxeC9u7u7SW1z5syZpCx37twmtTX2R1TBggVTbQeQI9GSP05OTiYfq2OixWVz5sxpUtvEfyQB5MuXz6S2xhKrqfEmfp7v6upqcltjcZjSNl++fEnKfHx8jCb5xBL/TDg6Opocr5OT4aknR44cJrU19nOTJ08ek9rmzp07SVmhQoVMunJ0d3fX/nP6NAQF4QLo9+jjA07Jn0oTnz+8vLxMijd//iRnCfLnz29S23SdI1xdYdIkbdHmIUNwN3+G0azB3PuwW7duVc7OzsrBwUG5u7urPn36qI0bN6rbt2+rqKgoFRUVpW7fvq02bNigevfurdzd3ZVOp1POzs5qy5YtFr4rbFxUVJRydHRUq1atMigfMmSIatiwodE2DRo0UEOGDDEoW7VqlXJyclLR0dEm7dekmSRCQpT64gulChVK/nlkvXpK3b5t0j6FEDb09deGv6slSmgzz2RVK1aoUBeXbPnM0ezkqJRSy5YtUzlz5lQ6nU45ODik+NLpdCpHjhxqyZIllo49RbVq1VLvvfeeQVnFihVT7JBTsWJFg7IBAwakrUOOKT9E0dFKLVmi/XIZS5AFCyq1b5/J+860jh9XqnVrpfLmVapbN6Xu3LF3REIYd/eu9nuZ8Pf03XftHZXVhW7dKsnRHOfOnVOdOnVSjo6OSqfTGX05Ojqqzp07q8DAQEvGbJKlS5cqZ2dnNX/+fBUYGKg+/PBD5eHhoa5evaqUUmrkyJGqe/fu+vqXL19WOXLkUEOHDlWBgYFq/vz5ytnZWa1YscLkfaZpDsLHj5UaOlQpB4ekCdLJSak5c0zfVmYSHKxUnz5K6XSGx1y4sFIHDtg7OiEMxcUp1bFj0t/RzZvtHZnVZde5VdO0ZFVCwcHB7Nq1izNnzhASEgJA3rx5qVSpEk2aNDH52ZI1zJo1i6+//pqgoCCqVKnCt99+S8OGDQHt+enVq1fZtWuXvv7u3bsZOnQoZ86coVChQnzyyScm9eSMl66lXQ4f1paVuXYt6Weffw6ffqpN+5QVHDsGzZtrz1+NcXKCadNg8OCsc8wic/vpJ+jXz7CsVSvYuDHL/4xm1yWr0p0cxX/S/UMUEgJvvaVN6ZTYRx9p09BlhV/Epk21eR1T88knWseArHDMIvO6eFFbozFhz+l8+bTOOXb8499WsmtyNGuGnPSIi4tj/fr1dOzY0Va7zHzy5oXNmyHR+EwAvvlGmwPxxx+1JJpZXbqUNDF6eECCsZd6kydrE7jL32/Cnt57zzAxAixYkC0SY3Zm9eR44cIFRo4cSZEiRejYsSPr16+39i4zN0dH7Wppxoykn+3dC+++q/1Sdu0K589bJ4aoqBTHbaXLokWG7/PkgQsXtNvKn36atP7kydofC5IghT3s2KEtApxQ//7Qrp194hG2Y40HmREREWrhwoWqQYMGBr1W43u3ZlUWf3D9669KOTomP+TDwUGpnj2VunLFMvtTSqmDB//rkVenjlKnT1tu2zExShUpYngMiYbPqEWLknbSAaWqV1dq/fqs3W1eZCxxcUrVrZu0w1gKC7xnRdm1Q45Fk+PBgwdVv379lJeXl0FCzJUrl+rZs6ckx7RYv15boTuleVpz5lRq+/b07+vCBW1IRcJtu7ho4zKfPUv/9jdvThq7kZXHk02QoFStWkotW6YNhRHCmjZuTPrzl1V7j6dAkmMa3b17V33zzTeqUqVKBleJzs7Oql27dmr58uUqMjJSPX78WJJjWkVEKLV8uVKvvaaUm5vxpOHmptSff6Z9H/fuKVWmTPIJuHZtpYKCUt5GXJwWZ6tWSr3wgtamSRPt6nb3bqVef91wmzVqJL+tlBIkaFegkyYpFR6e9mMWIjlxcdrdioQ/cyVLZo0Jxs0kydEMcXFxauPGjapTp07KxcXF4CrxpZdeUt9//726d++eQRtJjhYSEqLUp59qKwEkThguLkpt2GD+Np8+1WblSenqFLTkmdwt3IMHk96CSu31ww8px7Vpk1Lly6e8jeLFlbLRzEsiG1m5MunP2qJF9o7KLiQ5muDff/9Vn376qSpcuLBBQixevLj69NNP1blz55JtK8nRwu7cUapTp6S/wM7OSk2Zoj3fM1XPnsavzIxNTFCokFJnzvzXNjRUqV69zEuKoJSrq1IPHqQe27NnSv3yi1KlS6e8vR49tMkDsuFf9sLCoqOVqlDB8OerfHnLPFrIhCQ5miA+uel0OuXt7a3eeecdtWvXLpPaSnK0gmfPlOra1XiyaNRIqeezAaVo4ULjifHWLaUOHdJuJSX+3NNTqQ8+UGrFCuOfm/J66y3zjjU6WqmlS5Xy9095u25u2rH/739K/fWXdkvaHE+fZtuToHhuypSkP1dLl9o7KruR5GiC+OTWoEEDde3aNbN2JMnRSmJijF/5gVJeXtpVV3I9PM+cUSpHjqSJ79Sp/+rcvq09PzQn8ZUqpdTMmUr99JNSEycq5eOTtE56OhAdOaJU48amxeLsrNQrr2i3xJJbpDsuTnte26qVdrWcN69S33wjSTI7unkz6SOLGjWUio21d2R2I8nRBK6urvoE5+Liotq1a6f++OMPFRkZmWpbSY5WFBur1MiRyXdg6dIl6S3MiAilKldOWnfZsqTbDwnRhnWklog8PZWaNk2pxD8Pjx9rPV7z59fmi/3oI8sc87x52h8ApiZtFxctUX77rVIBAUqtW6c9v61UyXj96tWVOno0bfE9eaJdWX/zjVIjRijVt69SM2bIbd+M7s03k/4cHDpk76jsSpKjCR4+fKi+//57Vb16dYNxi97e3qpv374p3mKV5GgDu3ZpHVSMneiLFNGGhSil9Uxt2TJpnQEDkt/248faqhnJJeD69VMfbxkXZ/kxYjdvKvXhh8YTvSVeDg5KjRpl3lXk7t3JD79p2TLbjZPLNHbsSPr96tPH3lHZnd3Pa3ZiVnJM6MSJE2rgwIEqd+7cBktXFS9eXI0ePVqdPXvWoL4kR5sFkfxtVtCWhzK2lmTVqtrzttRcuqRdCeXL99/V2BdfmNcByFpCQrQ/AD7+WBsPmdIECua+6tdX6saN1GNYvFj7mqS0LX9/0zojCdt5/DhpJ5xcubRlqrK5DHFes4M0J8d4kZGR6rffflNNmjTRd9aJT5Txwzru3r0rydHW/vhDqdy5TTvx58yp1Pnz5m0/MlJbizHRkJ0MJTRUWzOzffvUExZoJ8fJk5O/zZo3b/JDZeLilPr8c9OT7QsvpD5uVNhO795Jv0ezZtk7qgwhQ53XbCjdyTGhy5cvq9GjR6uiRYsa3HZ1cXFRLVq0kORoazduKNW0aconaR8f7TZgVvfwofYHwzvvaFOAgdbxonFj7XntX3/91+kiKkq7GnZ2Nv41GzAg6a3R0aON161aVXuOlSdP0s/KldNuCwv7WrQo6femZs2McTckA8hw5zUbsWhyjBcXF6c2b96sOnfurFxcXAyGgEhytLG4OKV+/lmpAgWSngCaN8+eVy9xcUqFhaX+HPHwYaVKlDCe9MqV0yYfiI1V6quvjNcZMuS/E+w//xi/nV26tFLXr1v/mIVxxnps58ypTaUolFIZ9LxmA1ZJjgndu3dPffPNN6pKlSqSHO3p4UOl3n9f61GaJ4829Vo27p5usgcPjK8AH/8qWjRpmU6n1PTpSbd15YrxKfpKljRtTKqwrMhIpapUSfr9+P13e0eWoWTo85oV2XSx40OHDrFgwQLmzZtnq13aVKZYFDQmBuLiwMXF3pFkHkrBvHkwbFjSdf2M+ekn6NPH+Ge3b2uLPSdebqxwYW0tzxdeSH+8wjQTJ8KYMYZl/fvDnDn2iSeDyhTnNSuwaXLM6rLrD1G2ceECdO8OR44kX+fbb+HDD1PeTnAwNGsGgYGG5V5esGoVFCumfRYVBa+8opULy7p4UftDJCrqv7IXX4RDh8Dd3X5xZUDZ9bxm9cWOhcgyypWDfftg9myoXDnp5xMmpJ4YQVuseudOqFLFsDwsDF5+WdtPx47QpQuULq1dtcbGWuIIBGh3At57zzAxOjhoC3FLYhTPSXIUwhzOzjBgAJw+DXv2QO/e2lXgL7/AZ5+Zvp0CBWD3bqhXL+V69+9rt/r8/ODAgfTFLjSLF8P27YZlH3wA1avbJx6RIcltVQvKrrcfRDo8fQpvv63dTk2NoyN89x0MHAg6nfVjy+x++UV7juvkBPnyaVeH27fD338b1itSBM6ehZw57RNnBpddz2tZ8srx4cOHdO/eHW9vb7y9venevTuPHj1Ksc2qVato2bIl+fLlQ6fTcfLkSZvEKrI5d3f44w/tyiWh3LmT1o2NhcGDtVuCz57ZJj5TKQVHj8Inn2i3i8uXh+nTtQ5g9vDrr9CzJyxdCr/9psUybVrSxAjwww+SGEUSWTI5du3alZMnT7Jlyxa2bNnCyZMn6d69e4ptIiIiqFevHl999ZWNohTiOUdH7eR94QLs3w9378KDB/DXX8afbc6dC9WqwejRsHev/RIQaM/tvv8eSpWCWrXg66/hzBntWIYOhZo1bX87ODYWxo0zrW7HjtChgzWjEZlUlrutevbsWSpVqsShQ4eoXbs2oA0h8ff359y5c5QvXz7F9levXqVkyZIEBARQrVo1s/adXW8/CCuKiYHx4+Hzz5OvU6IE/Pij1pnHmgIDYcUKiIgAX1/tanH6dLh+PfW2b74JI0dC1arWjRFg9Wro1CnlOl5e0Lmz1rvY29v6MWVi2fW85mTvACzt4MGDeHt76xMjQJ06dfD29ubAgQOpJkdzREVFEZWgx1tYWJjFti0EoD0vmzhRu1XZqxdERiatc/UqNG+u3ZqdNMk6PS5v3YLGjeHevbS1X7pUe7VurV3x1q1r0fAMTJtm+L5UKWjQAB4/1noCt2oFdeponauESEaWu60aHBxMgQIFkpQXKFCA4OBgi+5r0qRJ+uea3t7eFC1a1KLbF0KvSxdtGEmZMsnX+e477Tbm6dOW3/+cOaYlxjJl4OOPtTGDxmzapPXQbdsWrPFc/8gR7euU0MSJ2jCNFSvgyy+1RCmJUaQi0yTHcePGodPpUnwdO3YMAJ2RnnxKKaPl6TFq1ChCQ0P1rxs3blh0+0IYqFlTu7W5c6fW8cXY88izZ6F2bfj5Z8vtNy5O69SSkgYNtKEtFy5ozx2PH9eu4Dw9jdffuFEbOtGtGwQFWS7Wb781fF+4MLz+uuW2L7KNTHNbdfDgwbz55psp1ilRogSnTp3izp07ST67d+8ePj4+Fo3J1dUVV1dXi25TiBQ5O2u3Nxs31q6CZs6EESMMb7c+fardgt27F2bMgBw50rfP/fu1W7cJ+ftDaKg2ScGgQdCiheHwEicnrUNOz54wa5Z2VXv/ftJtL1kCGzbAF19oyf7gQS2x3rqlJc07d7SeuU5OWselnDm1MaI+PlC8uPacNX4WoV27YPlyw+0PGSJXiSJt7Darq5UEBgYqQB0+fFhfdujQIQWoc+fOpdr+ypUrClABAQFm7zu7TtAr7CwwUKkaNZJfPeTgwfRtv18/w21WrKitbGKOx4+V+vZb46vDpPfl4KCUt3fScg8PWVTaArLreS3T3FY1VcWKFXnllVfo168fhw4d4tChQ/Tr14+2bdsadMapUKECq1ev1r9/8OABJ0+eJPD5fJfnz5/n5MmTFn9OKYTFVayoDZcYODDpZxcuaM/4Ro6EkBDztx0ZqY3DTKh7d/MnIfDw0KbWu3RJu0q0ZA/RuDjtKjaxd94xPl5UCFPYOztbQ0hIiOrWrZvy9PRUnp6eqlu3burhw4cGdQC1cOFC/fuFCxcqIMlr7NixJu83u/6FJTKQxYu1KyZjV1hOTkq1bq3Ub79pyzWZYvnypMtxXbuW/jjv3lWqRw/LX0XGv3LnlnUyLSS7ntey3DhHe8qu44FEBnPunPasL6XVQypU0MZG1q+f8rY6dIB16/5736QJ7NhhmThB61w0aJDWkcjRUZvcoG5dqFRJG0vp46MNTYmN1cZ8hoZqzyGDgrQOQNu3a89Y4734IrRrp81/W6SI5eLMxrLreU2SowVl1x8ikQHFxGi9RseNS3mquYEDtbGRxn5e79/XElTCGXgWLNAmW7ckpbQOPwUKaLdfzfH0qdZhKDxc681brJhlYxPZ9rwmydGCsusPkcjA/vlHW0pr/XrjEwiANjB++/akV1pffqkN2I/n5qZdtcnPdraSXc9rWa5DjhAigSpVtA41d+5ok3HXrJm0zoUL0KiR4TRwd+9C4nmGO3aUxCiyDUmOQmQHXl7a0liHD2uD8xOPfbx8WUuQ8eMZx43TblXG0+m0iQeEyCYkOQqRnTg6aoPzT5/WOuUkdPWqNufo1Kkwb57hZz17ap1lhMgm5JmjBWXXe/Mik7pzB5o21aakS4m7u3brVXp/ZkvZ9bwmV45CZFc+PtqUay+8kHK9jz6SxCiyHUmOQmRn+fNrYw3btDH+uY+PNnerENmMJEchsru8ebWhHitXGh/OkdzKGkJkYZlmVY7MIP7xrSx6LDKll1+GQ4e0VTSOHNFWu3jtNZCf52wt/nyW3bqnSIccC7p8+TKlS5e2dxhCCGFxly5dolSpUvYOw2bkytGC8uTJA8D169fxtuSqAxlcWFgYRYsW5caNG9mqN5sctxx3dhAaGkqxYsX057fsQpKjBTk4aI9wvb29s9UvTzwvLy857mxEjjt7iT+/ZRfZ62iFEEIIE0hyFEIIIRKR5GhBrq6ujB07FldXV3uHYlNy3HLc2YEcd/Y6bumtKoQQQiQiV45CCCFEIpIchRBCiEQkOQohhBCJSHIUQgghEpHkaKZZs2ZRsmRJ3NzcqFmzJnv37k2x/u7du6lZsyZubm6UKlWKOXPm2ChSyzLnuFetWkXz5s3Jnz8/Xl5e+Pv78+eff9owWssx9/sdb//+/Tg5OVEtky4QbO5xR0VFMXr0aIoXL46rqyulS5dmwYIFNorWcsw97sWLF1O1alVy5MiBr68vvXv3JiQkxEbRpt+ePXto164dhQoVQqfTsWbNmlTbZJVzWqqUMNnSpUuVs7Oz+vHHH1VgYKD64IMPlIeHh7p27ZrR+pcvX1Y5cuRQH3zwgQoMDFQ//vijcnZ2VitWrLBx5Olj7nF/8MEHavLkyerIkSPqwoULatSoUcrZ2VmdOHHCxpGnj7nHHe/Ro0eqVKlSqkWLFqpq1aq2CdaC0nLc7du3V7Vr11bbtm1TV65cUYcPH1b79++3YdTpZ+5x7927Vzk4OKjvvvtOXb58We3du1dVrlxZdezY0caRp92mTZvU6NGj1cqVKxWgVq9enWL9rHJOM4UkRzPUqlVLDRgwwKCsQoUKauTIkUbrjxgxQlWoUMGgrH///qpOnTpWi9EazD1uYypVqqTGjx9v6dCsKq3H3aVLF/XZZ5+psWPHZsrkaO5xb968WXl7e6uQkBBbhGc15h73lClTVKlSpQzKZsyYoYoUKWK1GK3JlOSYVc5pppDbqiaKjo7m+PHjtGjRwqC8RYsWHDhwwGibgwcPJqnfsmVLjh07xrNnz6wWqyWl5bgTi4uLIzw8PFNNXJzW4164cCGXLl1i7Nix1g7RKtJy3OvWrcPPz4+vv/6awoULU65cOYYPH87Tp09tEbJFpOW469aty82bN9m0aRNKKe7cucOKFStok9zC0VlAVjinmUomHjfR/fv3iY2NxcfHx6Dcx8eH4OBgo22Cg4ON1o+JieH+/fv4+vpaLV5LSctxJ/bNN98QERHBG2+8YY0QrSItx33x4kVGjhzJ3r17cXLKnL9aaTnuy5cvs2/fPtzc3Fi9ejX3799n4MCBPHjwINM8d0zLcdetW5fFixfTpUsXIiMjiYmJoX379nz//fe2CNkussI5zVRy5WgmnU5n8F4plaQstfrGyjM6c4873u+//864ceNYtmwZBQoUsFZ4VmPqccfGxtK1a1fGjx9PuXLlbBWe1Zjz/Y6Li0On07F48WJq1apF69atmTZtGosWLcpUV49g3nEHBgYyZMgQxowZw/Hjx9myZQtXrlxhwIABtgjVbrLKOS01mfPPWzvIly8fjo6OSf6KvHv3bpK/pOIVLFjQaH0nJyfy5s1rtVgtKS3HHW/ZsmX06dOH5cuX8/LLL1szTIsz97jDw8M5duwYAQEBDB48GNCShlIKJycntm7dStOmTW0Se3qk5fvt6+tL4cKFDdYwrVixIkopbt68SdmyZa0asyWk5bgnTZpEvXr1+PjjjwF48cUX8fDwoEGDBnz++edZ6ioqXlY4p5lKrhxN5OLiQs2aNdm2bZtB+bZt26hbt67RNv7+/knqb926FT8/P5ydna0WqyWl5bhBu2Ls1asXS5YsyZTPYMw9bi8vL06fPs3Jkyf1rwEDBlC+fHlOnjxJ7dq1bRV6uqTl+12vXj1u377N48eP9WUXLlzAwcGBIkWKWDVeS0nLcT958iTJGoeOjo7Af1dTWU1WOKeZzE4dgTKl+K7e8+fPV4GBgerDDz9UHh4e6urVq0oppUaOHKm6d++urx/f7Xno0KEqMDBQzZ8/P1N2ezb3uJcsWaKcnJzUzJkzVVBQkP716NEjex1Cmph73Ill1t6q5h53eHi4KlKkiHrttdfUmTNn1O7du1XZsmVV37597XUIaWLucS9cuFA5OTmpWbNmqUuXLql9+/YpPz8/VatWLXsdgtnCw8NVQECACggIUICaNm2aCggI0A9fyarnNFNIcjTTzJkzVfHixZWLi4uqUaOG2r17t/6znj17qkaNGhnU37Vrl6pevbpycXFRJUqUULNnz7ZxxJZhznE3atRIAUlePXv2tH3g6WTu9zuhzJoclTL/uM+ePatefvll5e7urooUKaKGDRumnjx5YuOo08/c454xY4aqVKmScnd3V76+vqpbt27q5s2bNo467Xbu3Jni72pWPqelRpasEkIIIRKRZ45CCCFEIpIchRBCiEQkOQohhBCJSHIUQgghEpHkKIQQQiQiyVEIIYRIRJKjEEIIkYgkRyGEECIRSY5CCCFEIpIchRBZWq9evdDpdPTq1cveoYhMRJKjSFFkZCRz586lXbt2FCtWDHd3d7y9valYsSL9+/dnz5499g4xU6pWrRo6nY7t27ebVH/cuHHodLokLzc3N4oUKUL79u35448/jK4GkbBtQsa2Z+pr0aJFKcbbr18/dDodefPmJSoqyuSvS5kyZdDpdLRv397kNkJYg6znKJK1bds23nnnHW7evKkv8/LyIioqinPnznHu3DnmzZtHu3bt+Pnnn8mdO7cdo808rl27xt9//02uXLlo2LCh2e0Tri8YGhrKrVu3uHXrFv9v786DoizjOIB/gV121zjFCzURNF10MCFHQJhRGE+UrFAJEDRw1JQyNdNJI0fTdGjEPIpmFEzywGMIV6A8Qs0c0wxI5VBRAxFNluVY4thln/5g9p199+AWxH6fGWbgfZ/n2d+u4G+fc2UyGQ4cOICUlBSIRKI2taNLqVSipqam2TISiaTZtqOiorBv3z6Ul5cjNTUV8+bNazGeixcvorCwkKtPSHeiniMx6tixYwgICMCjR48waNAg7j+6yspK1NXVIS8vDx999BEEAgFkMhkmTJgAuVze3WH3CKmpqQCAgICAdn0G3pMnT7ivmpoa3Lp1C1OmTAEAZGRkYMOGDW1uR/fr448/brFMcHBws217eXlh1KhRAIDExMRWxaMt179//x75GaDk5ULJkRjIz89HZGQk1Go13NzckJWVhaioKF7PUCqVIi4uDqmpqbC0tER+fj4WLFjQjVH3HNrkOHv27A63ZW5ujtGjR+PUqVMYPnw4AOC7776DWq3ucNsdpe39nTlzhjf6YEx1dTVOnDgBAIiIiIBAQINapHtRciQG1q9fj5qaGohEIhw/fhx9+/Y1WTYgIIDrqaSlpeHcuXNdFWaPpFAocOnSJVhaWmL69Omd1q5YLMbcuXMBNCWa/Pz8Tmu7vcLDwyEUCqHRaPD99983WzY5OZkbyo2MjOTdq6ysxNGjRxEWFgY3Nzf07t0bYrEYTk5OCA0NxdWrV9sV39ChQ1ucP23NYp4nT55g3bp1eP3112FrawuxWAwXFxcsWrQIubm57YqNdD9KjoSntLQUP/74IwAgJCQEI0eObLHOypUrYW1tDQDYs2fP8wyvx0tLS4NarYa/vz9sbGw6te3Bgwdz31dVVXVq2+3Rt29fbmFNSwt4tEOqPj4+kEqlvHtxcXEICQnB4cOHcevWLahUKgBAUVERjhw5ggkTJmDXrl2d/wRa4fTp03jttdewfft2/PXXX6itrYVAIMCDBw+wf/9+uLu74+DBg90SG+kYSo6E58KFC9BoNACAoKCgVtWxsrLC1KlTATQtqtDWJ4Y6c0hV38OHD7nve/fu3entt4d2aPXevXsmVzYXFBTgypUrAAx7jQAwYMAArFy5ElevXoVCoUB1dTVqa2tx//59rFixAgCwatUqZGVlPadnYdy1a9cQFBQEpVKJJUuWIC8vD7W1tVAqlfj777+xbNkyNDQ0ICoqCn/88UeXxkY6jpIj4bl9+zb3vbu7e6vrjR07FgBQUVGBoqKizg7rpVBfX4+ffvrpuWxVqKqqwqFDhwA0JcYRI0Z0avvtNW3aNK5Hm5CQYLSM9rqVlZXRVa1Lly7Fjh074OnpCTs7OwBN21CcnZ2xc+dOLFu2DI2Njdi7d+/zeRImREdHo6GhAZ999hni4+MhlUphYWEBABgyZAj27t2LDz/8EGq1Gl988UWXxkY6jpIj4dFdcerg4NDqen369DHaRksGDx6Mt956q9Xle7JffvkFSqUS48aNw8CBAzulzYqKCpw/fx7+/v54/PgxAGDFihUwN38x/rTNzc25hVonTpyAUqnk3W9sbERSUhIAIDg4GFZWVm1+DO3K1suXL3cw2tbLycnB9evXIRQKsXr1apPlIiIiAADnzp1DY2NjV4VHOgEtCSOdQnfzuf6m7927d8POzg7h4eG863K5HCUlJXjvvfe6JMbupp3L7eiQqv5mfl3z58/H+vXrO9R+Z4uMjMTWrVtRU1OD5ORk3h7GjIwMlJaWcuVMuX//Pr755htkZmaisLAQ1dXVBsP3La2I7UzaRKzRaJqdl9cmxJqaGsjlcvTr169L4iMdR8mR8Oj2FuVyOQYNGtSqerq9Rd0tH3V1dVi9ejXef/99g+SYnZ0NAHBzc+tAxD0DYwwymQwAOtxT1t2YLxKJ0KdPH7i7uyMsLAx+fn4davt5cHFxwaRJk5CZmYmEhARectQOqUqlUkyYMMFo/ZSUFISEhPDedNnY2EAsFsPMzAwNDQ1QKBTcateuoO2lNzY24unTp62q8++//z7PkEgno+RIeLQbtwHgzz//bHVy1C6GEAgEcHFx4V1XqVQYP368QZ2cnBwAwJgxYzoScqdTqVQQCATN9tDa6tq1aygtLcWwYcMwevToDrX15MmTToqq60RFRSEzMxNXrlxBQUEBRo4cibKyMpw+fZq7b4xcLsfChQtRX18Pf39/xMTEYPz48bwTes6fP4/Jkyd3yfPQ0vYIpVIp8vLyuvSxSdd4MSYmyAvDz8+Pm686efJkq+oolUqcPXsWAODt7c0dXTZ9+nSuNzB//nzuXE5tDyo7OxsikQjW1tZYsmQJHB0dYW1tjZkzZ3JDbbry8/MRERGBgQMHQiKRYMyYMSb3z2VlZWHu3Lno168fxGIxxo0bh/T0dINyUVFR6NWrFwoLCxEaGgoHBwdYW1tj/vz5EAqFqK2tNaiTmJgIMzOzNu3pfJ6rVHuCoKAgbjGNdttGUlIS90ZEf1RBKz09HVVVVbC3t4dMJsPEiRMNjq5r75sF7UEDdXV1JstUVlYavT5gwAAATcO9XdljJV2HkiPhcXR05Ib9jh49ioKCghbrxMXFobq6GgB4p+QsX74ckyZNglAoRFJSEvfl6+sLoKnnaG9vDx8fH2g0GmzcuBHh4eFIT0/HqlWreI9x7tw5eHh4ICsrCytWrMCOHTswcOBALFy40GAf2fHjx+Hp6YkHDx7g008/RWxsLBobGxEYGGhw0Hd2djasra3h4+MDgUCALVu2IDY2Fl5eXlCr1QbbA2pqarBhwwbMnDmzTb2Vzppv7KnEYjFCQ0MBAAcPHkRjYyOXJGfNmmXyDNfi4mIAwMiRI9GrVy+jZdp78IR2+F/7GPo0Go3JLRg+Pj4AgIaGBqSkpLTr8ckLjhGi5/bt20wikTAAzM3NjT179sxk2fT0dGZpackAMKlUyhoaGnj3fX192dixYw3q1dfXM6FQyCwsLNj58+cN6ri4uHA/P3r0iNna2rJ58+YxtVrNXddoNMzb25vX/q1bt5ilpSV75513mEql4q6Xl5czGxsbNnnyZO6aSqViIpGIAWDHjx/nxfD7778zAOzrr7/mXY+JiWECgYDl5uaafE303b17lwFgffr04cXfFp9//jkDwNrzJ9vWuh15rObcuHGDa1f3MWQymck6e/bsYQBY7969WW1trcH9rKws7vfPVLwLFixgANiCBQt416OiohgA5urqyjQajUG9hIQErl39uhqNhrm7uzMAbMiQIeyff/5p9rnL5fJm75MXD/UciYFRo0Zh3759sLCwwM2bN+Hu7o6EhARUVFRwZe7cuYNVq1bhzTffRENDA2xtbXH06FHeQdqMMeTk5BjdL5mbmwuVSoXFixfD39+fd08kEvGGzjZt2gSNRoOtW7dCoVCgrKwMZWVlkMvlGDNmDO7evcuV3bJlC8zMzPDtt9/yzue0t7eHm5sb7ty5w13Ly8tDfX093n33XcyZM4cXw9ixYyESiXg9h5KSEnz11VdYvHgxXF1dW/16anuNs2bN4vbB/R95eHhw+2E3b94MoGmkYsaMGSbrTJ06Febm5igvL0dYWBhKSkoANPXYjh07hqlTp3KnM7VVSEgIgKbfg8WLF3OLyqqqqhAXF4elS5eaPEzBzMwM8fHxEIlEKCoqgqenJ06cOMFbdFNSUoIffvgBU6ZMwdq1a9sVI+lG3Z2dyYsrPT2dOTo6cu+eATBbW1smFot511xcXNiNGzcM6mt7TLt27TK4d+DAAQaAZWZmGtxzdHRkQUFBjDHG1Go1s7e35z2e/pejoyNjrKkn+Morr3B19fn6+jJXV1fu54MHDzIA7NSpU0bLe3l5MalUyv0cERHBbGxsWuwlGHtcACwlJaVN9XS9DD1HxhjbvXs3799u3bp1LdZZu3atwe+gUChkAJizszM7dOhQu3qOjDX9m+q2bWdnx8zNzRkAFh0d3Wxdxhg7c+YMc3Bw4OpbWFgwBwcH1qtXL167ixYtasvLRF4AtFqVmDRjxgwUFhYiMTERaWlpyMnJQVlZGW9JfXh4OOLj443OB2nn64z1HLOzs2FmZoZx48bxrj99+hSlpaVcneLiYigUCixfvtzkFgjtGaXaxRHGenUajQZ5eXm8eUJtDKY+U9HLywu7du1CdXU17t69i6SkJHz55ZfNHsSu79mzZ7hy5QokEgl3xN7/WVhYGNasWcMtgmlub6PWtm3bMHr0aOzZswc3b96ESqXC8OHD8fbbb+OTTz7p0LFxCQkJeOONN5CYmIiCggJoNBr4+PggOjoa8+bNa/bAcQCYMmUK7t27h/j4eKSlpSE3NxcVFRWQSCQYNWoUvL29MXv2bO4jxUgP0t3ZmfQ8arWaBQYGcu/ijfUaGWNs/fr1zMzMjFVVVRnc8/PzYyNGjDC4npGRwQCwtLQ0xhhjOTk5DACLjY1tMa47d+4wAGzz5s0G91JTUxkAdvjwYe6av78/GzZsmMn2jhw5wgCwCxcusIkTJzInJydWV1fXYhy69u/fzwCwwMDANtUjhHQvmnMkbWZhYYHk5GR4e3ujsrIS06ZNM/rRPA8fPoSdnZ3ROaGcnBxu/kmXfm/TyckJAoEAJ0+eNHqgue4GbGdnZ0gkEoNjxB4/fowPPvgArq6uvLlFU/OhWl5eXgCAmJgYXLx4Edu2beO2qbSWdgvH/+WIPEJeFjSsStpFIpFAJpPB19cX+fn5mDx5Mn799VcMGzaMKzN06FAoFAqsXbsWbm5usLW1RWBgIIqLi1FeXm40MWVlZaF///5wdHQEANja2mLJkiXYu3cvvLy8EBwcDGtraxQVFeHy5cvo378/kpOTATTtW1uzZg02bdqE0NBQ+Pn54dGjR4iPj4eFhQVOnTrFLRgqLi6GXC6Hh4eHyec4dOhQ9OvXD5cuXYKnpyeCg4Pb/Dr5+PjA3d39f7uFg5Aeq7u7ruTlpVAo2Jw5c7gFNQEBAYwxxmQyGQPAMjIyDOoMHz6cTZs2jXdNrVaz+Ph45uHhwWxsbJiVlRUbMWIEi4yMZNeuXTMou3HjRvbqq68yoVDInJycWHR0tMF2lOZi0BUQEMAAsN9++609LwEhpIcyY0znxGhCCEepVMLZ2Rl+fn44duxYd4dDCOlCNOdIiAkbN26EUqnE9u3buzsUQkgXozlHQnSUl5fj559/xvXr17Fz507ExsbC2dm5u8MihHQxSo6E6Dh79ixCQ0MxYMAAxMTENPtBtoSQlxfNORJCCCF6aM6REEII0UPJkRBCCNFDyZEQQgjRQ8mREEII0UPJkRBCCNFDyZEQQgjRQ8mREEII0UPJkRBCCNFDyZEQQgjRQ8mREEII0UPJkRBCCNFDyZEQQgjR8x/qZ9pSUlSiJAAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 400x500 with 3 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
     "from matplotlib import gridspec\n",
@@ -920,33 +905,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "49bb4cfe-af95-45f1-91f1-ed9c08009f82",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'yvals': array([[2.02474504e-04, 2.52175666e-04, 3.13140510e-04, ...,\n",
-       "         1.13905148e-10, 7.87888065e-11, 5.43361014e-11],\n",
-       "        [2.02397480e-04, 2.52081194e-04, 3.13024967e-04, ...,\n",
-       "         1.13941218e-10, 7.88137530e-11, 5.43534148e-11],\n",
-       "        [2.02803241e-04, 2.52574273e-04, 3.13622011e-04, ...,\n",
-       "         1.14306700e-10, 7.90715382e-11, 5.45345215e-11],\n",
-       "        ...,\n",
-       "        [2.02474504e-04, 2.52175666e-04, 3.13140510e-04, ...,\n",
-       "         1.13905148e-10, 7.87888065e-11, 5.43361014e-11],\n",
-       "        [7.99800759e-04, 9.60611568e-04, 1.15084025e-03, ...,\n",
-       "         2.29681203e-09, 1.67570755e-09, 1.21947180e-09],\n",
-       "        [2.02474504e-04, 2.52175666e-04, 3.13140510e-04, ...,\n",
-       "         1.13905148e-10, 7.87888065e-11, 5.43361014e-11]])}"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "res.objdata()"
    ]

--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -138,7 +138,7 @@ def train(config, all_metadata, train_head=True):
             model, training_loader, optimizer, cfg, cfg_loader, hookList
         )
 
-        trainer.set_period(period)
+        trainer.set_period(epochs_per_print)
         trainer.train(0, full_iters)
 
         if comm.is_main_process():

--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import tempfile
-
+from fvcore.common.checkpoint import Checkpointer
 import detectron2.data as d2data
 import detectron2.solver as solver
 import detectron2.utils.comm as comm
@@ -250,14 +250,11 @@ class DeepDiscInformer(CatInformer):
         )
 
 
-        import detectron2.checkpoint as checkpointer
-
-        self.checkpointer = checkpointer.DetectionCheckpointer(
-            self.model,
-            self.config.output_dir,
-        )
-        # load weights
-        weights = self.checkpointer.load(os.path.join(self.config.output_dir, self.config.output_name + ".pth"))
+        cfg = get_lazy_config(self.config.cfgfile, self.config.batch_size, self.config.numclasses)
+        model = instantiate(cfg.model)
+        file_path = os.path.join("./", "deepdisc_informer" + ".pth")
+        fv_cp = Checkpointer(model, "./")
+        weights = fv_cp._load_file(file_path)
 
         self.model = dict(model_weights=weights)
         self.add_data("model", self.model)

--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -248,7 +248,17 @@ class DeepDiscInformer(CatInformer):
             ),
         )
 
-        self.model = dict(nnmodel=self.model)
+
+        import detectron2.checkpoint as checkpointer
+
+        self.checkpointer = checkpointer.DetectionCheckpointer(
+            self.model,
+            self.config.output_dir,
+        )
+        # load weights
+        weights = self.checkpointer.load(os.path.join(self.config.output_dir, self.config.output_name + ".pth"))
+
+        self.model = dict(model_weights=weights)
         self.add_data("model", self.model)
 
     def _get_dist_url(self):
@@ -368,7 +378,7 @@ class DeepDiscPDFEstimator(CatEstimator):
     def open_model(self, **kwargs):
         CatEstimator.open_model(self, **kwargs)
         if self.model is not None:
-            self.nnmodel = self.model["nnmodel"]
+            self.nnmodel = self.model["model_weights"]
 
     def run(self):
         """


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
Addressing issue #9 
WIP to use RAIL DataStore to pipe the model weights between Informer and Estimator stages.

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
