### PR TITLE
Fix bug when using `training_percent`

### DIFF
--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -57,8 +57,9 @@ def train(config, all_metadata, train_head=True):
 
     # Create slices for the input data
     total_images = len(all_metadata)
-    train_slice = slice( int(np.floor(total_images * config[training_percent])) )
-    eval_slice = slice( int(np.floor(total_images * config[training_percent])), total_images )
+    split_index = int(np.floor(total_images * training_percent))
+    train_slice = slice(split_index)
+    eval_slice = slice(split_index, total_images)
 
     mapper = RedshiftDictMapper(
         DC2ImageReader(), lambda dataset_dict: dataset_dict["filename"]


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
We were calling `config[training_percent]` but `training_percent` was defined to be 0.8 by default, so we were actually trying to call `config[0.8]`, which doesn't make much sense. This PR fixes that bug. 

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
