### PR TITLE
Make lossHook usage optional based on training percentage

### DIFF
--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -85,7 +85,7 @@ def train(config, all_metadata, train_head=True):
     if training_percent >= 1.0:
         # don't do lossHook
         hookList = [schedulerHook, saveHook]
-        print(f"The lossHook has been omitted, as the training percent is {training_percent}. To include it, set the training percent to a value between 0 and 1.")
+        print(f"The validation loss has been omitted, as the training percent is {training_percent}. To include it, set the training percent to a value between 0 and 1.")
     else:
         lossHook = return_evallosshook(val_per, model, eval_loader)
         hookList = [lossHook, schedulerHook, saveHook]

--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -80,10 +80,15 @@ def train(config, all_metadata, train_head=True):
 
 
     saveHook = return_savehook(run_name)
-    lossHook = return_evallosshook(val_per, model, eval_loader)
     schedulerHook = return_schedulerhook(optimizer)
-    #hookList = [lossHook, schedulerHook, saveHook]
-    hookList = [schedulerHook, saveHook]
+
+    if training_percent >= 1.0:
+        # don't do lossHook
+        hookList = [schedulerHook, saveHook]
+        print(f"The lossHook has been omitted, as the training percent is {training_percent}. To include it, set the training percent to a value between 0 and 1.")
+    else:
+        lossHook = return_evallosshook(val_per, model, eval_loader)
+        hookList = [lossHook, schedulerHook, saveHook]
 
     if train_head:
 


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
Resolves #27.

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
