### PR TITLE
Use json chunking in Estimation stage.

### DIFF
--- a/estimation_stage_only.ipynb
+++ b/estimation_stage_only.ipynb
@@ -2,19 +2,10 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "d614d238-437b-44f0-99da-4c710e2f8309",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/drewoldag/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import rail\n",
     "from rail.estimation.algos.deepdisc import *\n",
@@ -24,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "4d53926d-78e8-4fa3-a0e8-3ec3a3fdc18c",
    "metadata": {},
    "outputs": [],
@@ -35,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "029dedea-8be8-46a0-93a6-0b8ae840db9d",
    "metadata": {},
    "outputs": [],
@@ -52,13 +43,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "d0adfc74-3159-48dc-b379-e462ae02686e",
    "metadata": {},
    "outputs": [],
    "source": [
     "deep_estimation_dict = dict(\n",
-    "    chunk_size=20,\n",
+    "    chunk_size=5,\n",
     "    output_dir=\"./\",\n",
     "    cfgfile = cfgfile,\n",
     "    zmin=0,\n",
@@ -76,63 +67,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "4bb55a78-337b-4af9-8804-436873a54074",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Caching data\n",
-      "Processing chunk (start:end) - (0:10)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/drewoldag/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/torch/functional.py:504: UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument. (Triggered internally at /data/miniconda3/envs/opence-1.7/conda-bld/pytorch-base_1672876060819/work/aten/src/ATen/native/TensorShape.cpp:3190.)\n",
-      "  return _VF.meshgrid(tensors, **kwargs)  # type: ignore[attr-defined]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Matching objects\n"
-     ]
-    },
-    {
-     "ename": "RuntimeError",
-     "evalue": "cuDNN error: CUDNN_STATUS_INTERNAL_ERROR",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[5], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m results_from_chunks \u001b[38;5;241m=\u001b[39m \u001b[43mEstimatorWithChunks\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mestimate\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtest_handle_for_chunks\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmetadatahandle_with_chunks\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/code/rail_deepdisc/src/rail/estimation/algos/deepdisc.py:448\u001b[0m, in \u001b[0;36mDeepDiscPDFEstimatorWithChunking.estimate\u001b[0;34m(self, input_data, input_metadata)\u001b[0m\n\u001b[1;32m    446\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mset_data(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124minput\u001b[39m\u001b[38;5;124m\"\u001b[39m, input_data)\n\u001b[1;32m    447\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mset_data(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmetadata\u001b[39m\u001b[38;5;124m\"\u001b[39m, input_metadata)\n\u001b[0;32m--> 448\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    449\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mfinalize()\n\u001b[1;32m    450\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mget_handle(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124moutput\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
-      "File \u001b[0;32m~/code/rail_deepdisc/src/rail/estimation/algos/deepdisc.py:492\u001b[0m, in \u001b[0;36mDeepDiscPDFEstimatorWithChunking.run\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    490\u001b[0m \u001b[38;5;66;03m# process this chunk of data\u001b[39;00m\n\u001b[1;32m    491\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mProcessing chunk (start:end) - (\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mstart_idx\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m:\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mend_idx\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m)\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m--> 492\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_process_chunk\u001b[49m\u001b[43m(\u001b[49m\u001b[43mstart_idx\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmetadata\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/code/rail_deepdisc/src/rail/estimation/algos/deepdisc.py:505\u001b[0m, in \u001b[0;36mDeepDiscPDFEstimatorWithChunking._process_chunk\u001b[0;34m(self, start_idx, metadata)\u001b[0m\n\u001b[1;32m    502\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpredictor \u001b[38;5;241m=\u001b[39m return_predictor_transformer(cfg, checkpoint\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mnnmodel)\n\u001b[1;32m    504\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mMatching objects\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m--> 505\u001b[0m true_zs, pdfs \u001b[38;5;241m=\u001b[39m \u001b[43mget_matched_z_pdfs\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    506\u001b[0m \u001b[43m    \u001b[49m\u001b[43mmetadata\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    507\u001b[0m \u001b[43m    \u001b[49m\u001b[43mDC2ImageReader\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    508\u001b[0m \u001b[43m    \u001b[49m\u001b[38;5;28;43;01mlambda\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mdataset_dict\u001b[49m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[43mdataset_dict\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mfilename\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    509\u001b[0m \u001b[43m    \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpredictor\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    510\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    511\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mtrue_zs \u001b[38;5;241m=\u001b[39m true_zs\n\u001b[1;32m    512\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpdfs \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39marray(pdfs)\n",
-      "File \u001b[0;32m~/code/deepdisc/src/deepdisc/inference/match_objects.py:150\u001b[0m, in \u001b[0;36mget_matched_z_pdfs\u001b[0;34m(dataset_dicts, imreader, key_mapper, predictor)\u001b[0m\n\u001b[1;32m    147\u001b[0m zpreds \u001b[38;5;241m=\u001b[39m []\n\u001b[1;32m    149\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m d \u001b[38;5;129;01min\u001b[39;00m dataset_dicts:\n\u001b[0;32m--> 150\u001b[0m     outputs \u001b[38;5;241m=\u001b[39m \u001b[43mget_predictions\u001b[49m\u001b[43m(\u001b[49m\u001b[43md\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mimreader\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mkey_mapper\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpredictor\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    151\u001b[0m     matched_gts, matched_dts \u001b[38;5;241m=\u001b[39m get_matched_object_inds(d, outputs)\n\u001b[1;32m    153\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m gti, dti \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mzip\u001b[39m(matched_gts, matched_dts):\n",
-      "File \u001b[0;32m~/code/deepdisc/src/deepdisc/inference/predictors.py:48\u001b[0m, in \u001b[0;36mget_predictions\u001b[0;34m(dataset_dict, imreader, key_mapper, predictor)\u001b[0m\n\u001b[1;32m     46\u001b[0m key \u001b[38;5;241m=\u001b[39m key_mapper(dataset_dict)\n\u001b[1;32m     47\u001b[0m img \u001b[38;5;241m=\u001b[39m imreader(key)\n\u001b[0;32m---> 48\u001b[0m outputs \u001b[38;5;241m=\u001b[39m \u001b[43mpredictor\u001b[49m\u001b[43m(\u001b[49m\u001b[43mimg\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     49\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m outputs\n",
-      "File \u001b[0;32m~/code/deepdisc/src/deepdisc/astrodet/astrodet.py:308\u001b[0m, in \u001b[0;36mAstroPredictor.__call__\u001b[0;34m(self, original_image)\u001b[0m\n\u001b[1;32m    305\u001b[0m image \u001b[38;5;241m=\u001b[39m torch\u001b[38;5;241m.\u001b[39mas_tensor(original_image\u001b[38;5;241m.\u001b[39mastype(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mfloat32\u001b[39m\u001b[38;5;124m\"\u001b[39m)\u001b[38;5;241m.\u001b[39mtranspose(\u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m1\u001b[39m))\n\u001b[1;32m    307\u001b[0m inputs \u001b[38;5;241m=\u001b[39m {\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mimage\u001b[39m\u001b[38;5;124m\"\u001b[39m: image, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mheight\u001b[39m\u001b[38;5;124m\"\u001b[39m: height, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mwidth\u001b[39m\u001b[38;5;124m\"\u001b[39m: width}\n\u001b[0;32m--> 308\u001b[0m predictions \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmodel\u001b[49m\u001b[43m(\u001b[49m\u001b[43m[\u001b[49m\u001b[43minputs\u001b[49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    309\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m predictions\n",
-      "File \u001b[0;32m~/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/torch/nn/modules/module.py:1190\u001b[0m, in \u001b[0;36mModule._call_impl\u001b[0;34m(self, *input, **kwargs)\u001b[0m\n\u001b[1;32m   1186\u001b[0m \u001b[38;5;66;03m# If we don't have any hooks, we want to skip the rest of the logic in\u001b[39;00m\n\u001b[1;32m   1187\u001b[0m \u001b[38;5;66;03m# this function, and just call forward.\u001b[39;00m\n\u001b[1;32m   1188\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m (\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_backward_hooks\n\u001b[1;32m   1189\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_forward_pre_hooks):\n\u001b[0;32m-> 1190\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mforward_call\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;28;43minput\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1191\u001b[0m \u001b[38;5;66;03m# Do not call functions when jit is used\u001b[39;00m\n\u001b[1;32m   1192\u001b[0m full_backward_hooks, non_full_backward_hooks \u001b[38;5;241m=\u001b[39m [], []\n",
-      "File \u001b[0;32m~/code/detectron2/detectron2/modeling/meta_arch/rcnn.py:150\u001b[0m, in \u001b[0;36mGeneralizedRCNN.forward\u001b[0;34m(self, batched_inputs)\u001b[0m\n\u001b[1;32m    127\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    128\u001b[0m \u001b[38;5;124;03mArgs:\u001b[39;00m\n\u001b[1;32m    129\u001b[0m \u001b[38;5;124;03m    batched_inputs: a list, batched outputs of :class:`DatasetMapper` .\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    147\u001b[0m \u001b[38;5;124;03m        \"pred_boxes\", \"pred_classes\", \"scores\", \"pred_masks\", \"pred_keypoints\"\u001b[39;00m\n\u001b[1;32m    148\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    149\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mtraining:\n\u001b[0;32m--> 150\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43minference\u001b[49m\u001b[43m(\u001b[49m\u001b[43mbatched_inputs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    152\u001b[0m images \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpreprocess_image(batched_inputs)\n\u001b[1;32m    153\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124minstances\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01min\u001b[39;00m batched_inputs[\u001b[38;5;241m0\u001b[39m]:\n",
-      "File \u001b[0;32m~/code/detectron2/detectron2/modeling/meta_arch/rcnn.py:204\u001b[0m, in \u001b[0;36mGeneralizedRCNN.inference\u001b[0;34m(self, batched_inputs, detected_instances, do_postprocess)\u001b[0m\n\u001b[1;32m    201\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mtraining\n\u001b[1;32m    203\u001b[0m images \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpreprocess_image(batched_inputs)\n\u001b[0;32m--> 204\u001b[0m features \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mbackbone\u001b[49m\u001b[43m(\u001b[49m\u001b[43mimages\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtensor\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    206\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m detected_instances \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m    207\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mproposal_generator \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n",
-      "File \u001b[0;32m~/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/torch/nn/modules/module.py:1190\u001b[0m, in \u001b[0;36mModule._call_impl\u001b[0;34m(self, *input, **kwargs)\u001b[0m\n\u001b[1;32m   1186\u001b[0m \u001b[38;5;66;03m# If we don't have any hooks, we want to skip the rest of the logic in\u001b[39;00m\n\u001b[1;32m   1187\u001b[0m \u001b[38;5;66;03m# this function, and just call forward.\u001b[39;00m\n\u001b[1;32m   1188\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m (\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_backward_hooks\n\u001b[1;32m   1189\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_forward_pre_hooks):\n\u001b[0;32m-> 1190\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mforward_call\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;28;43minput\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1191\u001b[0m \u001b[38;5;66;03m# Do not call functions when jit is used\u001b[39;00m\n\u001b[1;32m   1192\u001b[0m full_backward_hooks, non_full_backward_hooks \u001b[38;5;241m=\u001b[39m [], []\n",
-      "File \u001b[0;32m~/code/detectron2/detectron2/modeling/backbone/fpn.py:139\u001b[0m, in \u001b[0;36mFPN.forward\u001b[0;34m(self, x)\u001b[0m\n\u001b[1;32m    126\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mforward\u001b[39m(\u001b[38;5;28mself\u001b[39m, x):\n\u001b[1;32m    127\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    128\u001b[0m \u001b[38;5;124;03m    Args:\u001b[39;00m\n\u001b[1;32m    129\u001b[0m \u001b[38;5;124;03m        input (dict[str->Tensor]): mapping feature map name (e.g., \"res5\") to\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    137\u001b[0m \u001b[38;5;124;03m            [\"p2\", \"p3\", ..., \"p6\"].\u001b[39;00m\n\u001b[1;32m    138\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 139\u001b[0m     bottom_up_features \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mbottom_up\u001b[49m\u001b[43m(\u001b[49m\u001b[43mx\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    140\u001b[0m     results \u001b[38;5;241m=\u001b[39m []\n\u001b[1;32m    141\u001b[0m     prev_features \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mlateral_convs[\u001b[38;5;241m0\u001b[39m](bottom_up_features[\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39min_features[\u001b[38;5;241m-\u001b[39m\u001b[38;5;241m1\u001b[39m]])\n",
-      "File \u001b[0;32m~/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/torch/nn/modules/module.py:1190\u001b[0m, in \u001b[0;36mModule._call_impl\u001b[0;34m(self, *input, **kwargs)\u001b[0m\n\u001b[1;32m   1186\u001b[0m \u001b[38;5;66;03m# If we don't have any hooks, we want to skip the rest of the logic in\u001b[39;00m\n\u001b[1;32m   1187\u001b[0m \u001b[38;5;66;03m# this function, and just call forward.\u001b[39;00m\n\u001b[1;32m   1188\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m (\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_backward_hooks\n\u001b[1;32m   1189\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_forward_pre_hooks):\n\u001b[0;32m-> 1190\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mforward_call\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;28;43minput\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1191\u001b[0m \u001b[38;5;66;03m# Do not call functions when jit is used\u001b[39;00m\n\u001b[1;32m   1192\u001b[0m full_backward_hooks, non_full_backward_hooks \u001b[38;5;241m=\u001b[39m [], []\n",
-      "File \u001b[0;32m~/code/detectron2/detectron2/modeling/backbone/swin.py:670\u001b[0m, in \u001b[0;36mSwinTransformer.forward\u001b[0;34m(self, x)\u001b[0m\n\u001b[1;32m    668\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mforward\u001b[39m(\u001b[38;5;28mself\u001b[39m, x):\n\u001b[1;32m    669\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Forward function.\"\"\"\u001b[39;00m\n\u001b[0;32m--> 670\u001b[0m     x \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpatch_embed\u001b[49m\u001b[43m(\u001b[49m\u001b[43mx\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    672\u001b[0m     Wh, Ww \u001b[38;5;241m=\u001b[39m x\u001b[38;5;241m.\u001b[39msize(\u001b[38;5;241m2\u001b[39m), x\u001b[38;5;241m.\u001b[39msize(\u001b[38;5;241m3\u001b[39m)\n\u001b[1;32m    673\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mape:\n\u001b[1;32m    674\u001b[0m         \u001b[38;5;66;03m# interpolate the position embedding to the corresponding size\u001b[39;00m\n",
-      "File \u001b[0;32m~/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/torch/nn/modules/module.py:1190\u001b[0m, in \u001b[0;36mModule._call_impl\u001b[0;34m(self, *input, **kwargs)\u001b[0m\n\u001b[1;32m   1186\u001b[0m \u001b[38;5;66;03m# If we don't have any hooks, we want to skip the rest of the logic in\u001b[39;00m\n\u001b[1;32m   1187\u001b[0m \u001b[38;5;66;03m# this function, and just call forward.\u001b[39;00m\n\u001b[1;32m   1188\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m (\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_backward_hooks\n\u001b[1;32m   1189\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_forward_pre_hooks):\n\u001b[0;32m-> 1190\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mforward_call\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;28;43minput\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1191\u001b[0m \u001b[38;5;66;03m# Do not call functions when jit is used\u001b[39;00m\n\u001b[1;32m   1192\u001b[0m full_backward_hooks, non_full_backward_hooks \u001b[38;5;241m=\u001b[39m [], []\n",
-      "File \u001b[0;32m~/code/detectron2/detectron2/modeling/backbone/swin.py:500\u001b[0m, in \u001b[0;36mPatchEmbed.forward\u001b[0;34m(self, x)\u001b[0m\n\u001b[1;32m    497\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m H \u001b[38;5;241m%\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpatch_size[\u001b[38;5;241m0\u001b[39m] \u001b[38;5;241m!=\u001b[39m \u001b[38;5;241m0\u001b[39m:\n\u001b[1;32m    498\u001b[0m     x \u001b[38;5;241m=\u001b[39m F\u001b[38;5;241m.\u001b[39mpad(x, (\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m0\u001b[39m, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpatch_size[\u001b[38;5;241m0\u001b[39m] \u001b[38;5;241m-\u001b[39m H \u001b[38;5;241m%\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpatch_size[\u001b[38;5;241m0\u001b[39m]))\n\u001b[0;32m--> 500\u001b[0m x \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mproj\u001b[49m\u001b[43m(\u001b[49m\u001b[43mx\u001b[49m\u001b[43m)\u001b[49m  \u001b[38;5;66;03m# B C Wh Ww\u001b[39;00m\n\u001b[1;32m    501\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mnorm \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m    502\u001b[0m     Wh, Ww \u001b[38;5;241m=\u001b[39m x\u001b[38;5;241m.\u001b[39msize(\u001b[38;5;241m2\u001b[39m), x\u001b[38;5;241m.\u001b[39msize(\u001b[38;5;241m3\u001b[39m)\n",
-      "File \u001b[0;32m~/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/torch/nn/modules/module.py:1190\u001b[0m, in \u001b[0;36mModule._call_impl\u001b[0;34m(self, *input, **kwargs)\u001b[0m\n\u001b[1;32m   1186\u001b[0m \u001b[38;5;66;03m# If we don't have any hooks, we want to skip the rest of the logic in\u001b[39;00m\n\u001b[1;32m   1187\u001b[0m \u001b[38;5;66;03m# this function, and just call forward.\u001b[39;00m\n\u001b[1;32m   1188\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m (\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_backward_hooks\n\u001b[1;32m   1189\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_forward_pre_hooks):\n\u001b[0;32m-> 1190\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mforward_call\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;28;43minput\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1191\u001b[0m \u001b[38;5;66;03m# Do not call functions when jit is used\u001b[39;00m\n\u001b[1;32m   1192\u001b[0m full_backward_hooks, non_full_backward_hooks \u001b[38;5;241m=\u001b[39m [], []\n",
-      "File \u001b[0;32m~/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/torch/nn/modules/conv.py:463\u001b[0m, in \u001b[0;36mConv2d.forward\u001b[0;34m(self, input)\u001b[0m\n\u001b[1;32m    462\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mforward\u001b[39m(\u001b[38;5;28mself\u001b[39m, \u001b[38;5;28minput\u001b[39m: Tensor) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Tensor:\n\u001b[0;32m--> 463\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_conv_forward\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43minput\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mweight\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mbias\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/torch/nn/modules/conv.py:459\u001b[0m, in \u001b[0;36mConv2d._conv_forward\u001b[0;34m(self, input, weight, bias)\u001b[0m\n\u001b[1;32m    455\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpadding_mode \u001b[38;5;241m!=\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mzeros\u001b[39m\u001b[38;5;124m'\u001b[39m:\n\u001b[1;32m    456\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m F\u001b[38;5;241m.\u001b[39mconv2d(F\u001b[38;5;241m.\u001b[39mpad(\u001b[38;5;28minput\u001b[39m, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_reversed_padding_repeated_twice, mode\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpadding_mode),\n\u001b[1;32m    457\u001b[0m                     weight, bias, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mstride,\n\u001b[1;32m    458\u001b[0m                     _pair(\u001b[38;5;241m0\u001b[39m), \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdilation, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mgroups)\n\u001b[0;32m--> 459\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mF\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mconv2d\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43minput\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mweight\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mbias\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mstride\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    460\u001b[0m \u001b[43m                \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpadding\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mdilation\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mgroups\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[0;31mRuntimeError\u001b[0m: cuDNN error: CUDNN_STATUS_INTERNAL_ERROR"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "results_from_chunks = EstimatorWithChunks.estimate(test_handle_for_chunks, metadatahandle_with_chunks)"
    ]
@@ -143,7 +81,24 @@
    "id": "2bab95c9-2dab-48a1-a9a6-da272e586c20",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "res_ens = results_from_chunks.read()\n",
+    "res_ens.npdf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5dfc284e-7701-4a72-8370-49a405a71cfb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "fig, ax = plt.subplots()\n",
+    "x = np.linspace(0,3,100)\n",
+    "ax.plot(x, res_ens[0].pdf(x)[0])\n",
+    "ax.plot(x, res_ens[1].pdf(x)[0])"
+   ]
   }
  ],
  "metadata": {

--- a/estimation_stage_only.ipynb
+++ b/estimation_stage_only.ipynb
@@ -1,0 +1,170 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d614d238-437b-44f0-99da-4c710e2f8309",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/drewoldag/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "import rail\n",
+    "from rail.estimation.algos.deepdisc import *\n",
+    "from rail.core.data import TableHandle, JsonHandle, ModelHandle\n",
+    "from rail.core.stage import RailStage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4d53926d-78e8-4fa3-a0e8-3ec3a3fdc18c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DS = RailStage.data_store\n",
+    "DS.__class__.allow_overwrite = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "029dedea-8be8-46a0-93a6-0b8ae840db9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_file = \"./test_informer.pkl\"\n",
+    "model_handle = DS.add_data(\"model\", data=None, handle_class=ModelHandle, path=model_file)\n",
+    "test_file_for_chunks = \"/home/shared/hsc/DC2/test_data/dataset_3/flattened_images_test_small.hdf5\"\n",
+    "test_handle_for_chunks = DS.add_data(\"testing\", data=None, handle_class=TableHandle, path=test_file_for_chunks)\n",
+    "metadatafile_with_chunks = \"/home/shared/hsc/DC2/test_data/dataset_3/test_metadata_example.hdf5\"\n",
+    "metadatahandle_with_chunks = DS.add_data(\"metadata\", data=None, handle_class=Hdf5Handle, path=metadatafile_with_chunks)\n",
+    "\n",
+    "cfgfile = \"./configs/solo/solo_swin_DC2.py\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d0adfc74-3159-48dc-b379-e462ae02686e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "deep_estimation_dict = dict(\n",
+    "    chunk_size=20,\n",
+    "    output_dir=\"./\",\n",
+    "    cfgfile = cfgfile,\n",
+    "    zmin=0,\n",
+    "    zmax=5,\n",
+    "    nzbins=200,\n",
+    "    output_mode='default',\n",
+    ")\n",
+    "\n",
+    "EstimatorWithChunks = DeepDiscPDFEstimatorWithChunking.make_stage(\n",
+    "    name=\"DeepDiscEstimatorWithChunks\",\n",
+    "    model=model_file,\n",
+    "    **deep_estimation_dict,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "4bb55a78-337b-4af9-8804-436873a54074",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Caching data\n",
+      "Processing chunk (start:end) - (0:10)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/drewoldag/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/torch/functional.py:504: UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument. (Triggered internally at /data/miniconda3/envs/opence-1.7/conda-bld/pytorch-base_1672876060819/work/aten/src/ATen/native/TensorShape.cpp:3190.)\n",
+      "  return _VF.meshgrid(tensors, **kwargs)  # type: ignore[attr-defined]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Matching objects\n"
+     ]
+    },
+    {
+     "ename": "RuntimeError",
+     "evalue": "cuDNN error: CUDNN_STATUS_INTERNAL_ERROR",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[5], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m results_from_chunks \u001b[38;5;241m=\u001b[39m \u001b[43mEstimatorWithChunks\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mestimate\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtest_handle_for_chunks\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmetadatahandle_with_chunks\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/code/rail_deepdisc/src/rail/estimation/algos/deepdisc.py:448\u001b[0m, in \u001b[0;36mDeepDiscPDFEstimatorWithChunking.estimate\u001b[0;34m(self, input_data, input_metadata)\u001b[0m\n\u001b[1;32m    446\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mset_data(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124minput\u001b[39m\u001b[38;5;124m\"\u001b[39m, input_data)\n\u001b[1;32m    447\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mset_data(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmetadata\u001b[39m\u001b[38;5;124m\"\u001b[39m, input_metadata)\n\u001b[0;32m--> 448\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    449\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mfinalize()\n\u001b[1;32m    450\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mget_handle(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124moutput\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
+      "File \u001b[0;32m~/code/rail_deepdisc/src/rail/estimation/algos/deepdisc.py:492\u001b[0m, in \u001b[0;36mDeepDiscPDFEstimatorWithChunking.run\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    490\u001b[0m \u001b[38;5;66;03m# process this chunk of data\u001b[39;00m\n\u001b[1;32m    491\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mProcessing chunk (start:end) - (\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mstart_idx\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m:\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mend_idx\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m)\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m--> 492\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_process_chunk\u001b[49m\u001b[43m(\u001b[49m\u001b[43mstart_idx\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmetadata\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/code/rail_deepdisc/src/rail/estimation/algos/deepdisc.py:505\u001b[0m, in \u001b[0;36mDeepDiscPDFEstimatorWithChunking._process_chunk\u001b[0;34m(self, start_idx, metadata)\u001b[0m\n\u001b[1;32m    502\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpredictor \u001b[38;5;241m=\u001b[39m return_predictor_transformer(cfg, checkpoint\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mnnmodel)\n\u001b[1;32m    504\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mMatching objects\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m--> 505\u001b[0m true_zs, pdfs \u001b[38;5;241m=\u001b[39m \u001b[43mget_matched_z_pdfs\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    506\u001b[0m \u001b[43m    \u001b[49m\u001b[43mmetadata\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    507\u001b[0m \u001b[43m    \u001b[49m\u001b[43mDC2ImageReader\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    508\u001b[0m \u001b[43m    \u001b[49m\u001b[38;5;28;43;01mlambda\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mdataset_dict\u001b[49m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[43mdataset_dict\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mfilename\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    509\u001b[0m \u001b[43m    \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpredictor\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    510\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    511\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mtrue_zs \u001b[38;5;241m=\u001b[39m true_zs\n\u001b[1;32m    512\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpdfs \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39marray(pdfs)\n",
+      "File \u001b[0;32m~/code/deepdisc/src/deepdisc/inference/match_objects.py:150\u001b[0m, in \u001b[0;36mget_matched_z_pdfs\u001b[0;34m(dataset_dicts, imreader, key_mapper, predictor)\u001b[0m\n\u001b[1;32m    147\u001b[0m zpreds \u001b[38;5;241m=\u001b[39m []\n\u001b[1;32m    149\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m d \u001b[38;5;129;01min\u001b[39;00m dataset_dicts:\n\u001b[0;32m--> 150\u001b[0m     outputs \u001b[38;5;241m=\u001b[39m \u001b[43mget_predictions\u001b[49m\u001b[43m(\u001b[49m\u001b[43md\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mimreader\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mkey_mapper\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpredictor\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    151\u001b[0m     matched_gts, matched_dts \u001b[38;5;241m=\u001b[39m get_matched_object_inds(d, outputs)\n\u001b[1;32m    153\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m gti, dti \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mzip\u001b[39m(matched_gts, matched_dts):\n",
+      "File \u001b[0;32m~/code/deepdisc/src/deepdisc/inference/predictors.py:48\u001b[0m, in \u001b[0;36mget_predictions\u001b[0;34m(dataset_dict, imreader, key_mapper, predictor)\u001b[0m\n\u001b[1;32m     46\u001b[0m key \u001b[38;5;241m=\u001b[39m key_mapper(dataset_dict)\n\u001b[1;32m     47\u001b[0m img \u001b[38;5;241m=\u001b[39m imreader(key)\n\u001b[0;32m---> 48\u001b[0m outputs \u001b[38;5;241m=\u001b[39m \u001b[43mpredictor\u001b[49m\u001b[43m(\u001b[49m\u001b[43mimg\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     49\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m outputs\n",
+      "File \u001b[0;32m~/code/deepdisc/src/deepdisc/astrodet/astrodet.py:308\u001b[0m, in \u001b[0;36mAstroPredictor.__call__\u001b[0;34m(self, original_image)\u001b[0m\n\u001b[1;32m    305\u001b[0m image \u001b[38;5;241m=\u001b[39m torch\u001b[38;5;241m.\u001b[39mas_tensor(original_image\u001b[38;5;241m.\u001b[39mastype(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mfloat32\u001b[39m\u001b[38;5;124m\"\u001b[39m)\u001b[38;5;241m.\u001b[39mtranspose(\u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m1\u001b[39m))\n\u001b[1;32m    307\u001b[0m inputs \u001b[38;5;241m=\u001b[39m {\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mimage\u001b[39m\u001b[38;5;124m\"\u001b[39m: image, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mheight\u001b[39m\u001b[38;5;124m\"\u001b[39m: height, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mwidth\u001b[39m\u001b[38;5;124m\"\u001b[39m: width}\n\u001b[0;32m--> 308\u001b[0m predictions \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmodel\u001b[49m\u001b[43m(\u001b[49m\u001b[43m[\u001b[49m\u001b[43minputs\u001b[49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    309\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m predictions\n",
+      "File \u001b[0;32m~/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/torch/nn/modules/module.py:1190\u001b[0m, in \u001b[0;36mModule._call_impl\u001b[0;34m(self, *input, **kwargs)\u001b[0m\n\u001b[1;32m   1186\u001b[0m \u001b[38;5;66;03m# If we don't have any hooks, we want to skip the rest of the logic in\u001b[39;00m\n\u001b[1;32m   1187\u001b[0m \u001b[38;5;66;03m# this function, and just call forward.\u001b[39;00m\n\u001b[1;32m   1188\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m (\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_backward_hooks\n\u001b[1;32m   1189\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_forward_pre_hooks):\n\u001b[0;32m-> 1190\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mforward_call\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;28;43minput\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1191\u001b[0m \u001b[38;5;66;03m# Do not call functions when jit is used\u001b[39;00m\n\u001b[1;32m   1192\u001b[0m full_backward_hooks, non_full_backward_hooks \u001b[38;5;241m=\u001b[39m [], []\n",
+      "File \u001b[0;32m~/code/detectron2/detectron2/modeling/meta_arch/rcnn.py:150\u001b[0m, in \u001b[0;36mGeneralizedRCNN.forward\u001b[0;34m(self, batched_inputs)\u001b[0m\n\u001b[1;32m    127\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    128\u001b[0m \u001b[38;5;124;03mArgs:\u001b[39;00m\n\u001b[1;32m    129\u001b[0m \u001b[38;5;124;03m    batched_inputs: a list, batched outputs of :class:`DatasetMapper` .\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    147\u001b[0m \u001b[38;5;124;03m        \"pred_boxes\", \"pred_classes\", \"scores\", \"pred_masks\", \"pred_keypoints\"\u001b[39;00m\n\u001b[1;32m    148\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    149\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mtraining:\n\u001b[0;32m--> 150\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43minference\u001b[49m\u001b[43m(\u001b[49m\u001b[43mbatched_inputs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    152\u001b[0m images \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpreprocess_image(batched_inputs)\n\u001b[1;32m    153\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124minstances\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01min\u001b[39;00m batched_inputs[\u001b[38;5;241m0\u001b[39m]:\n",
+      "File \u001b[0;32m~/code/detectron2/detectron2/modeling/meta_arch/rcnn.py:204\u001b[0m, in \u001b[0;36mGeneralizedRCNN.inference\u001b[0;34m(self, batched_inputs, detected_instances, do_postprocess)\u001b[0m\n\u001b[1;32m    201\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mtraining\n\u001b[1;32m    203\u001b[0m images \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpreprocess_image(batched_inputs)\n\u001b[0;32m--> 204\u001b[0m features \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mbackbone\u001b[49m\u001b[43m(\u001b[49m\u001b[43mimages\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtensor\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    206\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m detected_instances \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m    207\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mproposal_generator \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n",
+      "File \u001b[0;32m~/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/torch/nn/modules/module.py:1190\u001b[0m, in \u001b[0;36mModule._call_impl\u001b[0;34m(self, *input, **kwargs)\u001b[0m\n\u001b[1;32m   1186\u001b[0m \u001b[38;5;66;03m# If we don't have any hooks, we want to skip the rest of the logic in\u001b[39;00m\n\u001b[1;32m   1187\u001b[0m \u001b[38;5;66;03m# this function, and just call forward.\u001b[39;00m\n\u001b[1;32m   1188\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m (\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_backward_hooks\n\u001b[1;32m   1189\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_forward_pre_hooks):\n\u001b[0;32m-> 1190\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mforward_call\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;28;43minput\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1191\u001b[0m \u001b[38;5;66;03m# Do not call functions when jit is used\u001b[39;00m\n\u001b[1;32m   1192\u001b[0m full_backward_hooks, non_full_backward_hooks \u001b[38;5;241m=\u001b[39m [], []\n",
+      "File \u001b[0;32m~/code/detectron2/detectron2/modeling/backbone/fpn.py:139\u001b[0m, in \u001b[0;36mFPN.forward\u001b[0;34m(self, x)\u001b[0m\n\u001b[1;32m    126\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mforward\u001b[39m(\u001b[38;5;28mself\u001b[39m, x):\n\u001b[1;32m    127\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    128\u001b[0m \u001b[38;5;124;03m    Args:\u001b[39;00m\n\u001b[1;32m    129\u001b[0m \u001b[38;5;124;03m        input (dict[str->Tensor]): mapping feature map name (e.g., \"res5\") to\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    137\u001b[0m \u001b[38;5;124;03m            [\"p2\", \"p3\", ..., \"p6\"].\u001b[39;00m\n\u001b[1;32m    138\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 139\u001b[0m     bottom_up_features \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mbottom_up\u001b[49m\u001b[43m(\u001b[49m\u001b[43mx\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    140\u001b[0m     results \u001b[38;5;241m=\u001b[39m []\n\u001b[1;32m    141\u001b[0m     prev_features \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mlateral_convs[\u001b[38;5;241m0\u001b[39m](bottom_up_features[\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39min_features[\u001b[38;5;241m-\u001b[39m\u001b[38;5;241m1\u001b[39m]])\n",
+      "File \u001b[0;32m~/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/torch/nn/modules/module.py:1190\u001b[0m, in \u001b[0;36mModule._call_impl\u001b[0;34m(self, *input, **kwargs)\u001b[0m\n\u001b[1;32m   1186\u001b[0m \u001b[38;5;66;03m# If we don't have any hooks, we want to skip the rest of the logic in\u001b[39;00m\n\u001b[1;32m   1187\u001b[0m \u001b[38;5;66;03m# this function, and just call forward.\u001b[39;00m\n\u001b[1;32m   1188\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m (\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_backward_hooks\n\u001b[1;32m   1189\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_forward_pre_hooks):\n\u001b[0;32m-> 1190\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mforward_call\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;28;43minput\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1191\u001b[0m \u001b[38;5;66;03m# Do not call functions when jit is used\u001b[39;00m\n\u001b[1;32m   1192\u001b[0m full_backward_hooks, non_full_backward_hooks \u001b[38;5;241m=\u001b[39m [], []\n",
+      "File \u001b[0;32m~/code/detectron2/detectron2/modeling/backbone/swin.py:670\u001b[0m, in \u001b[0;36mSwinTransformer.forward\u001b[0;34m(self, x)\u001b[0m\n\u001b[1;32m    668\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mforward\u001b[39m(\u001b[38;5;28mself\u001b[39m, x):\n\u001b[1;32m    669\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Forward function.\"\"\"\u001b[39;00m\n\u001b[0;32m--> 670\u001b[0m     x \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpatch_embed\u001b[49m\u001b[43m(\u001b[49m\u001b[43mx\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    672\u001b[0m     Wh, Ww \u001b[38;5;241m=\u001b[39m x\u001b[38;5;241m.\u001b[39msize(\u001b[38;5;241m2\u001b[39m), x\u001b[38;5;241m.\u001b[39msize(\u001b[38;5;241m3\u001b[39m)\n\u001b[1;32m    673\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mape:\n\u001b[1;32m    674\u001b[0m         \u001b[38;5;66;03m# interpolate the position embedding to the corresponding size\u001b[39;00m\n",
+      "File \u001b[0;32m~/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/torch/nn/modules/module.py:1190\u001b[0m, in \u001b[0;36mModule._call_impl\u001b[0;34m(self, *input, **kwargs)\u001b[0m\n\u001b[1;32m   1186\u001b[0m \u001b[38;5;66;03m# If we don't have any hooks, we want to skip the rest of the logic in\u001b[39;00m\n\u001b[1;32m   1187\u001b[0m \u001b[38;5;66;03m# this function, and just call forward.\u001b[39;00m\n\u001b[1;32m   1188\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m (\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_backward_hooks\n\u001b[1;32m   1189\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_forward_pre_hooks):\n\u001b[0;32m-> 1190\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mforward_call\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;28;43minput\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1191\u001b[0m \u001b[38;5;66;03m# Do not call functions when jit is used\u001b[39;00m\n\u001b[1;32m   1192\u001b[0m full_backward_hooks, non_full_backward_hooks \u001b[38;5;241m=\u001b[39m [], []\n",
+      "File \u001b[0;32m~/code/detectron2/detectron2/modeling/backbone/swin.py:500\u001b[0m, in \u001b[0;36mPatchEmbed.forward\u001b[0;34m(self, x)\u001b[0m\n\u001b[1;32m    497\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m H \u001b[38;5;241m%\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpatch_size[\u001b[38;5;241m0\u001b[39m] \u001b[38;5;241m!=\u001b[39m \u001b[38;5;241m0\u001b[39m:\n\u001b[1;32m    498\u001b[0m     x \u001b[38;5;241m=\u001b[39m F\u001b[38;5;241m.\u001b[39mpad(x, (\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m0\u001b[39m, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpatch_size[\u001b[38;5;241m0\u001b[39m] \u001b[38;5;241m-\u001b[39m H \u001b[38;5;241m%\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpatch_size[\u001b[38;5;241m0\u001b[39m]))\n\u001b[0;32m--> 500\u001b[0m x \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mproj\u001b[49m\u001b[43m(\u001b[49m\u001b[43mx\u001b[49m\u001b[43m)\u001b[49m  \u001b[38;5;66;03m# B C Wh Ww\u001b[39;00m\n\u001b[1;32m    501\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mnorm \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m    502\u001b[0m     Wh, Ww \u001b[38;5;241m=\u001b[39m x\u001b[38;5;241m.\u001b[39msize(\u001b[38;5;241m2\u001b[39m), x\u001b[38;5;241m.\u001b[39msize(\u001b[38;5;241m3\u001b[39m)\n",
+      "File \u001b[0;32m~/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/torch/nn/modules/module.py:1190\u001b[0m, in \u001b[0;36mModule._call_impl\u001b[0;34m(self, *input, **kwargs)\u001b[0m\n\u001b[1;32m   1186\u001b[0m \u001b[38;5;66;03m# If we don't have any hooks, we want to skip the rest of the logic in\u001b[39;00m\n\u001b[1;32m   1187\u001b[0m \u001b[38;5;66;03m# this function, and just call forward.\u001b[39;00m\n\u001b[1;32m   1188\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m (\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_backward_hooks\n\u001b[1;32m   1189\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_forward_pre_hooks):\n\u001b[0;32m-> 1190\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mforward_call\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;28;43minput\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1191\u001b[0m \u001b[38;5;66;03m# Do not call functions when jit is used\u001b[39;00m\n\u001b[1;32m   1192\u001b[0m full_backward_hooks, non_full_backward_hooks \u001b[38;5;241m=\u001b[39m [], []\n",
+      "File \u001b[0;32m~/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/torch/nn/modules/conv.py:463\u001b[0m, in \u001b[0;36mConv2d.forward\u001b[0;34m(self, input)\u001b[0m\n\u001b[1;32m    462\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mforward\u001b[39m(\u001b[38;5;28mself\u001b[39m, \u001b[38;5;28minput\u001b[39m: Tensor) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Tensor:\n\u001b[0;32m--> 463\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_conv_forward\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43minput\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mweight\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mbias\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/torch/nn/modules/conv.py:459\u001b[0m, in \u001b[0;36mConv2d._conv_forward\u001b[0;34m(self, input, weight, bias)\u001b[0m\n\u001b[1;32m    455\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpadding_mode \u001b[38;5;241m!=\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mzeros\u001b[39m\u001b[38;5;124m'\u001b[39m:\n\u001b[1;32m    456\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m F\u001b[38;5;241m.\u001b[39mconv2d(F\u001b[38;5;241m.\u001b[39mpad(\u001b[38;5;28minput\u001b[39m, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_reversed_padding_repeated_twice, mode\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpadding_mode),\n\u001b[1;32m    457\u001b[0m                     weight, bias, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mstride,\n\u001b[1;32m    458\u001b[0m                     _pair(\u001b[38;5;241m0\u001b[39m), \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdilation, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mgroups)\n\u001b[0;32m--> 459\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mF\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mconv2d\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43minput\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mweight\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mbias\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mstride\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    460\u001b[0m \u001b[43m                \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpadding\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mdilation\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mgroups\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[0;31mRuntimeError\u001b[0m: cuDNN error: CUDNN_STATUS_INTERNAL_ERROR"
+     ]
+    }
+   ],
+   "source": [
+    "results_from_chunks = EstimatorWithChunks.estimate(test_handle_for_chunks, metadatahandle_with_chunks)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2bab95c9-2dab-48a1-a9a6-da272e586c20",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "rail_deepdisc39",
+   "language": "python",
+   "name": "rail_deepdisc39"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/rail_wrap_test.ipynb
+++ b/rail_wrap_test.ipynb
@@ -198,14 +198,14 @@
       "Training head layers\n",
       "In launch function\n",
       "World size: 1\n",
-      "\u001b[32m[12/21 15:39:38 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
-      "\u001b[32m[12/21 15:39:38 d2.data.common]: \u001b[0mSerializing 800 elements to byte tensors and concatenating them all ...\n",
-      "\u001b[32m[12/21 15:40:00 d2.data.common]: \u001b[0mSerialized dataset takes 223.74 MiB\n",
-      "\u001b[32m[12/21 15:40:00 d2.data.build]: \u001b[0mMaking batched data loader with batch_size=1\n",
-      "\u001b[32m[12/21 15:40:00 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
-      "\u001b[32m[12/21 15:40:00 d2.data.common]: \u001b[0mSerializing 200 elements to byte tensors and concatenating them all ...\n",
-      "\u001b[32m[12/21 15:40:04 d2.data.common]: \u001b[0mSerialized dataset takes 55.56 MiB\n",
-      "\u001b[32m[12/21 15:40:22 d2.checkpoint.detection_checkpoint]: \u001b[0m[DetectionCheckpointer] Loading from /home/shared/hsc/detectron2/projects/ViTDet/model_final_246a82.pkl ...\n"
+      "\u001b[32m[12/22 18:41:51 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
+      "\u001b[32m[12/22 18:41:52 d2.data.common]: \u001b[0mSerializing 800 elements to byte tensors and concatenating them all ...\n",
+      "\u001b[32m[12/22 18:42:11 d2.data.common]: \u001b[0mSerialized dataset takes 223.74 MiB\n",
+      "\u001b[32m[12/22 18:42:11 d2.data.build]: \u001b[0mMaking batched data loader with batch_size=1\n",
+      "\u001b[32m[12/22 18:42:11 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
+      "\u001b[32m[12/22 18:42:11 d2.data.common]: \u001b[0mSerializing 200 elements to byte tensors and concatenating them all ...\n",
+      "\u001b[32m[12/22 18:42:15 d2.data.common]: \u001b[0mSerialized dataset takes 55.56 MiB\n",
+      "\u001b[32m[12/22 18:42:35 d2.checkpoint.detection_checkpoint]: \u001b[0m[DetectionCheckpointer] Loading from /home/shared/hsc/detectron2/projects/ViTDet/model_final_246a82.pkl ...\n"
      ]
     },
     {
@@ -236,30 +236,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m[12/21 15:40:22 d2.engine.train_loop]: \u001b[0mStarting training from iteration 0\n",
-      "<detectron2.solver.lr_scheduler.LRMultiplier object at 0x7ff6b682af70>\n",
-      "Iteration:  5  data time:  0.19410017505288124  loss time:  0.23707077698782086 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.6527390480041504, 0.09666723012924194, 0.5099961757659912, 0.32156988978385925, 0.5019933581352234, 0.6253546476364136, 0.6354149580001831, 0.12217867374420166, 1.8415673971176147, 0.33126288652420044] val loss:  0 lr:  [0.001]\n",
-      "Iteration:  10  data time:  0.12981196399778128  loss time:  0.2137882811948657 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.7394877076148987, 0.22434577345848083, 0.597769558429718, 0.3743278682231903, 0.5623451471328735, 0.4723976254463196, 0.5328865647315979, 0.12546296417713165, 0.6247153878211975, 0.23683761060237885] val loss:  0 lr:  [0.001]\n",
-      "Iteration:  15  data time:  0.2227790467441082  loss time:  0.28334785206243396 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.6638544201850891, 0.2878076732158661, 0.5407952070236206, 0.4644840955734253, 0.5297361612319946, 0.5976332426071167, 0.4481503963470459, 0.13756993412971497, 0.18266184628009796, 0.1945340633392334] val loss:  0 lr:  [0.001]\n",
-      "Iteration:  20  data time:  0.2107845377177  loss time:  0.26004094490781426 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.48777028918266296, 0.19738098978996277, 0.4442472457885742, 0.36665359139442444, 0.4389907121658325, 0.5308727025985718, 0.36784428358078003, 0.12873747944831848, 0.14766791462898254, 0.18052566051483154] val loss:  0 lr:  [0.001]\n",
+      "\u001b[32m[12/22 18:42:35 d2.engine.train_loop]: \u001b[0mStarting training from iteration 0\n",
+      "<detectron2.solver.lr_scheduler.LRMultiplier object at 0x7ff69ac26070>\n",
+      "Iteration:  5  data time:  1.0522300801239908  loss time:  0.29681939305737615 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5037013292312622, 0.16843944787979126, 0.7403606176376343, 0.4575991928577423, 0.4938681721687317, 0.6993744373321533, 0.6324691772460938, 0.11370821297168732, 2.002346992492676, 0.3122941851615906] val loss:  0 lr:  [0.001]\n",
+      "Iteration:  10  data time:  0.6905716829933226  loss time:  0.25867572892457247 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.6085929870605469, 0.23859384655952454, 0.5912017822265625, 0.5407350063323975, 0.6333305239677429, 1.2826005220413208, 0.5426815748214722, 0.1298362910747528, 0.8834578990936279, 0.204496830701828] val loss:  0 lr:  [0.001]\n",
+      "Iteration:  15  data time:  1.564404717180878  loss time:  0.4856375381350517 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5638263821601868, 0.3005742132663727, 0.607978880405426, 0.5232330560684204, 0.5338194370269775, 0.5117809176445007, 0.45188355445861816, 0.12964603304862976, 0.2902817130088806, 0.24353452026844025] val loss:  0 lr:  [0.001]\n",
+      "Iteration:  20  data time:  1.3705780040472746  loss time:  0.4064302551560104 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5297995209693909, 0.1727180778980255, 0.5258011817932129, 0.28415346145629883, 0.5042040944099426, 0.43133604526519775, 0.3553069829940796, 0.12488095462322235, 0.182449609041214, 0.1619674563407898] val loss:  0 lr:  [0.001]\n",
       "saving run\n",
       "Training full model\n",
       "In launch function\n",
       "World size: 1\n",
-      "\u001b[32m[12/21 15:40:43 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
-      "\u001b[32m[12/21 15:40:43 d2.data.common]: \u001b[0mSerializing 800 elements to byte tensors and concatenating them all ...\n",
-      "\u001b[32m[12/21 15:41:02 d2.data.common]: \u001b[0mSerialized dataset takes 223.74 MiB\n",
-      "\u001b[32m[12/21 15:41:02 d2.data.build]: \u001b[0mMaking batched data loader with batch_size=1\n",
-      "\u001b[32m[12/21 15:41:02 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
-      "\u001b[32m[12/21 15:41:02 d2.data.common]: \u001b[0mSerializing 200 elements to byte tensors and concatenating them all ...\n",
-      "\u001b[32m[12/21 15:41:03 d2.data.common]: \u001b[0mSerialized dataset takes 55.56 MiB\n",
-      "\u001b[32m[12/21 15:41:13 d2.checkpoint.detection_checkpoint]: \u001b[0m[DetectionCheckpointer] Loading from ./run.pth ...\n",
-      "\u001b[32m[12/21 15:41:13 d2.engine.train_loop]: \u001b[0mStarting training from iteration 0\n",
-      "<detectron2.solver.lr_scheduler.LRMultiplier object at 0x7ff6a3de6790>\n",
-      "Iteration:  5  data time:  0.17509440332651138  loss time:  0.25536190532147884 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5094579458236694, 0.24878017604351044, 0.502326250076294, 0.5008976459503174, 0.4618081748485565, 0.7207968235015869, 0.3495076894760132, 0.1222446858882904, 0.1800243854522705, 0.190628319978714] val loss:  0 lr:  [0.001, 0.001]\n",
-      "Iteration:  10  data time:  0.2070854571647942  loss time:  0.27092082891613245 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5610605478286743, 0.22642430663108826, 0.5160733461380005, 0.46356961131095886, 0.5045719146728516, 0.7461922764778137, 0.37207654118537903, 0.11303846538066864, 0.09658201038837433, 0.17738153040409088] val loss:  0 lr:  [0.001, 0.001]\n",
-      "Iteration:  15  data time:  0.17416224209591746  loss time:  0.2580165406689048 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5428526997566223, 0.3068872392177582, 0.5007061958312988, 0.43888741731643677, 0.4759419560432434, 0.606104850769043, 0.4021938741207123, 0.10056412220001221, 0.17451703548431396, 0.16259533166885376] val loss:  0 lr:  [0.001, 0.001]\n",
-      "Iteration:  20  data time:  0.20399827975779772  loss time:  0.2832088959403336 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5041361451148987, 0.24641898274421692, 0.5174290537834167, 0.38396722078323364, 0.4579388499259949, 0.49565136432647705, 0.3655903935432434, 0.09490177035331726, 0.12687581777572632, 0.1568266898393631] val loss:  0 lr:  [0.001, 0.001]\n",
+      "\u001b[32m[12/22 18:43:20 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
+      "\u001b[32m[12/22 18:43:20 d2.data.common]: \u001b[0mSerializing 800 elements to byte tensors and concatenating them all ...\n",
+      "\u001b[32m[12/22 18:43:43 d2.data.common]: \u001b[0mSerialized dataset takes 223.74 MiB\n",
+      "\u001b[32m[12/22 18:43:43 d2.data.build]: \u001b[0mMaking batched data loader with batch_size=1\n",
+      "\u001b[32m[12/22 18:43:43 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
+      "\u001b[32m[12/22 18:43:43 d2.data.common]: \u001b[0mSerializing 200 elements to byte tensors and concatenating them all ...\n",
+      "\u001b[32m[12/22 18:43:47 d2.data.common]: \u001b[0mSerialized dataset takes 55.56 MiB\n",
+      "\u001b[32m[12/22 18:43:58 d2.checkpoint.detection_checkpoint]: \u001b[0m[DetectionCheckpointer] Loading from ./run.pth ...\n",
+      "\u001b[32m[12/22 18:43:58 d2.engine.train_loop]: \u001b[0mStarting training from iteration 0\n",
+      "<detectron2.solver.lr_scheduler.LRMultiplier object at 0x7ff69af22fa0>\n",
+      "Iteration:  5  data time:  1.0468590259552002  loss time:  0.380195417907089 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.605675220489502, 0.2653862237930298, 0.49304530024528503, 0.3666379153728485, 0.5594156980514526, 0.46857911348342896, 0.39011508226394653, 0.11576427519321442, 0.15428216755390167, 0.1894700527191162] val loss:  0 lr:  [0.001, 0.001]\n",
+      "Iteration:  10  data time:  1.3192340806126595  loss time:  0.4382833302952349 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5601028203964233, 0.3147968649864197, 0.5474895238876343, 0.6594735383987427, 0.480986088514328, 1.2247438430786133, 0.4498133659362793, 0.10091117024421692, 0.10214663296937943, 0.1868215799331665] val loss:  0 lr:  [0.001, 0.001]\n",
+      "Iteration:  15  data time:  1.075973560102284  loss time:  0.38644196512177587 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5816810727119446, 0.23847299814224243, 0.5452905297279358, 0.3061836361885071, 0.4859592020511627, 0.4603598117828369, 0.3550771176815033, 0.09334017336368561, 0.12817241251468658, 0.1598472148180008] val loss:  0 lr:  [0.001, 0.001]\n",
+      "Iteration:  20  data time:  1.3834546231664717  loss time:  0.4178794529289007 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5129203200340271, 0.2655200958251953, 0.5087618827819824, 0.5217885375022888, 0.478546679019928, 0.5628805160522461, 0.4233054518699646, 0.08892480283975601, 0.07617291808128357, 0.17255885899066925] val loss:  0 lr:  [0.001, 0.001]\n",
       "saving run\n",
       "Inserting handle into data store.  model_Inform_DeepDISC: inprogress_test_informer.pkl, Inform_DeepDISC\n"
      ]
@@ -267,7 +267,7 @@
     {
      "data": {
       "text/plain": [
-       "<rail.core.data.ModelHandle at 0x7ff69d6af970>"
+       "<rail.core.data.ModelHandle at 0x7ff69b04c280>"
       ]
      },
      "execution_count": 9,
@@ -286,7 +286,8 @@
     "tags": []
    },
    "source": [
-    "### Inference"
+    "### Inference\n",
+    "Commenting this out to test the chunking estimator"
    ]
   },
   {
@@ -296,9 +297,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "metadatahandle = DS.add_data(\n",
-    "    \"metadata\", test_metadata, JsonHandle, path=test_metadatafile\n",
-    ")"
+    "# metadatahandle = DS.add_data(\n",
+    "#     \"metadata\", test_metadata, JsonHandle, path=test_metadatafile\n",
+    "# )"
    ]
   },
   {
@@ -308,36 +309,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Estimator = DeepDiscEstimator.make_stage(name='DeepDiscEstimator',\n",
-    "#                                       model=Inform.get_handle('model'), **deep_dict)\n",
-    "\n",
-    "Estimator = DeepDiscPDFEstimator.make_stage(\n",
-    "    name=\"DeepDiscEstimator\",\n",
-    "    model=Inform.get_handle(\"model\"),\n",
-    "    # hdf5_groupname=\"images\",\n",
-    "    **deep_dict,\n",
-    ")"
+    "# Estimator = DeepDiscPDFEstimator.make_stage(\n",
+    "#     name=\"DeepDiscEstimator\",\n",
+    "#     model=Inform.get_handle(\"model\"),\n",
+    "#     # hdf5_groupname=\"images\",\n",
+    "#     **deep_dict,\n",
+    "# )"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 24,
    "id": "6415a174-6d14-48f5-9241-963a84431501",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "StageConfig{cfgfile:./configs/solo/solo_swin_DC2.py,batch_size:1,output_dir:./,run_name:run,chunk_size:100,num_camera_filters:6,name:DeepDiscEstimator,model:<class 'rail.core.data.ModelHandle'> test_informer.pkl, (wd),epoch:20,num_gpus:1,print_frequency:5,head_epochs:1,full_epochs:1,config:None,input:None,metadata:None,aliases:{'output': 'output_DeepDiscEstimator', 'truth': 'truth_DeepDiscEstimator'},}"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
-    "Estimator.config"
+    "# Estimator.config"
    ]
   },
   {
@@ -345,20 +334,9 @@
    "execution_count": 13,
    "id": "c74bb222-f53c-415c-acab-f8b978a2af5d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Caching data\n",
-      "Matching objects\n",
-      "Inserting handle into data store.  output_DeepDiscEstimator: inprogress_output_DeepDiscEstimator.hdf5, DeepDiscEstimator\n",
-      "Inserting handle into data store.  truth_DeepDiscEstimator: inprogress_truth_DeepDiscEstimator, DeepDiscEstimator\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "results = Estimator.estimate(testing, metadatahandle)"
+    "# results = Estimator.estimate(testing, metadatahandle)"
    ]
   },
   {
@@ -366,21 +344,9 @@
    "execution_count": 14,
    "id": "5b402ba2-3779-44e7-8654-113f19731464",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<qp.ensemble.Ensemble at 0x7ff5fc4b68e0>"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "res = results.read()\n",
-    "res"
+    "# res = results.read()"
    ]
   },
   {
@@ -390,7 +356,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "truth = Estimator.get_handle(\"truth\")"
+    "# truth = Estimator.get_handle(\"truth\")"
    ]
   },
   {
@@ -400,131 +366,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ztrue = truth.data[\"redshift\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "id": "f15ba45d-6713-4c63-b153-151c1adc8905",
-   "metadata": {
-    "collapsed": true,
-    "jupyter": {
-     "outputs_hidden": true
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[0.7432564,\n",
-       " 0.6807421,\n",
-       " 0.40604848,\n",
-       " 0.7111039,\n",
-       " 0.5355953,\n",
-       " 0.0,\n",
-       " 1.2393405,\n",
-       " 0.5530237,\n",
-       " 0.75410193,\n",
-       " 0.0,\n",
-       " 0.5585447,\n",
-       " 1.4091417,\n",
-       " 0.5696309,\n",
-       " 0.56676906,\n",
-       " 1.0360764,\n",
-       " 0.52962214,\n",
-       " 0.7601911,\n",
-       " 0.5831668,\n",
-       " 0.30276734,\n",
-       " 1.3559166,\n",
-       " 1.0675421,\n",
-       " 0.62916094,\n",
-       " 0.22380716,\n",
-       " 1.7364438,\n",
-       " 0.24592146,\n",
-       " 2.6455407,\n",
-       " 1.0246825,\n",
-       " 0.0,\n",
-       " 0.88542485,\n",
-       " 0.93084246,\n",
-       " 0.84799784,\n",
-       " 0.56965196,\n",
-       " 0.44770825,\n",
-       " 0.0,\n",
-       " 0.0,\n",
-       " 1.0113244,\n",
-       " 0.69241905,\n",
-       " 0.27674484,\n",
-       " 0.7931073,\n",
-       " 0.3213708,\n",
-       " 0.81737053,\n",
-       " 1.0199007,\n",
-       " 0.84717727,\n",
-       " 0.0,\n",
-       " 0.39386645,\n",
-       " 0.0,\n",
-       " 2.425019,\n",
-       " 0.5053078,\n",
-       " 1.1667216,\n",
-       " 0.39279625,\n",
-       " 1.3866463,\n",
-       " 0.54890865,\n",
-       " 0.0,\n",
-       " 0.7983657,\n",
-       " 0.38405475,\n",
-       " 0.65973574,\n",
-       " 0.6006085,\n",
-       " 0.060146954,\n",
-       " 0.7484906,\n",
-       " 0.5289882,\n",
-       " 0.42111164,\n",
-       " 0.7728185,\n",
-       " 0.8621007,\n",
-       " 0.69428676,\n",
-       " 0.9497149,\n",
-       " 0.47963572,\n",
-       " 1.16648,\n",
-       " 0.767425,\n",
-       " 0.9695052,\n",
-       " 0.032379486,\n",
-       " 0.559502,\n",
-       " 0.4300901,\n",
-       " 0.637063,\n",
-       " 0.7512283,\n",
-       " 0.3777712,\n",
-       " 0.8552379,\n",
-       " 0.34845287,\n",
-       " 0.0,\n",
-       " 0.0,\n",
-       " 0.39419606,\n",
-       " 0.57076085,\n",
-       " 0.0,\n",
-       " 0.9531508,\n",
-       " 0.0,\n",
-       " 0.7833842,\n",
-       " 0.13510144,\n",
-       " 0.7536498,\n",
-       " 0.5971579,\n",
-       " 1.1287016,\n",
-       " 0.6789744,\n",
-       " 0.8509604,\n",
-       " 0.61471117,\n",
-       " 0.57857525,\n",
-       " 0.95642143,\n",
-       " 0.49101683,\n",
-       " 0.0,\n",
-       " 0.7112921,\n",
-       " 1.6229273]"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ztrue"
+    "# ztrue = truth.data[\"redshift\"]"
    ]
   },
   {
@@ -537,25 +379,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 17,
    "id": "48936320-ed0f-40c3-8329-1f3e2c7c31ac",
    "metadata": {},
    "outputs": [],
    "source": [
-    "EstimatorWithChunks = DeepDiscPDFEstimatorWithChunking.make_stage(\n",
-    "    name=\"DeepDiscEstimatorWithChunks\",\n",
-    "    model=Inform.get_handle(\"model\"),\n",
+    "deep_estimation_dict = dict(\n",
+    "    chunk_size=5,\n",
+    "    output_dir=\"./\",\n",
+    "    cfgfile = cfgfile,\n",
     "    zmin=0,\n",
     "    zmax=5,\n",
     "    nzbins=200,\n",
     "    output_mode='default',\n",
-    "    **deep_dict,\n",
+    ")\n",
+    "\n",
+    "EstimatorWithChunks = DeepDiscPDFEstimatorWithChunking.make_stage(\n",
+    "    name=\"DeepDiscEstimatorWithChunks\",\n",
+    "    model=Inform.get_handle(\"model\"),\n",
+    "    **deep_estimation_dict,\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 18,
    "id": "31f8a0c3-6ad4-430c-9892-b70ae4285ab9",
    "metadata": {},
    "outputs": [],
@@ -568,12 +416,115 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "c684e258-6c71-476f-bf35-79b53df86282",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Caching data\n",
+      "Processing chunk (start:end) - (0:5)\n",
+      "\u001b[32m[12/22 18:49:46 d2.checkpoint.detection_checkpoint]: \u001b[0m[DetectionCheckpointer] Loading from /home/shared/hsc/detectron2/projects/ViTDet/model_final_246a82.pkl ...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Skip loading parameter 'backbone.bottom_up.patch_embed.proj.weight' to the model due to incompatible shapes: (128, 3, 4, 4) in the checkpoint but (128, 6, 4, 4) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.box_predictor.0.cls_score.weight' to the model due to incompatible shapes: (81, 1024) in the checkpoint but (2, 1024) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.box_predictor.0.cls_score.bias' to the model due to incompatible shapes: (81,) in the checkpoint but (2,) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.box_predictor.1.cls_score.weight' to the model due to incompatible shapes: (81, 1024) in the checkpoint but (2, 1024) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.box_predictor.1.cls_score.bias' to the model due to incompatible shapes: (81,) in the checkpoint but (2,) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.box_predictor.2.cls_score.weight' to the model due to incompatible shapes: (81, 1024) in the checkpoint but (2, 1024) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.box_predictor.2.cls_score.bias' to the model due to incompatible shapes: (81,) in the checkpoint but (2,) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.mask_head.predictor.weight' to the model due to incompatible shapes: (80, 256, 1, 1) in the checkpoint but (1, 256, 1, 1) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.mask_head.predictor.bias' to the model due to incompatible shapes: (80,) in the checkpoint but (1,) in the model! You might want to double check if this is expected.\n",
+      "Some model parameters or buffers are not found in the checkpoint:\n",
+      "\u001b[34mbackbone.bottom_up.patch_embed.proj.weight\u001b[0m\n",
+      "\u001b[34mroi_heads.box_predictor.0.cls_score.{bias, weight}\u001b[0m\n",
+      "\u001b[34mroi_heads.box_predictor.1.cls_score.{bias, weight}\u001b[0m\n",
+      "\u001b[34mroi_heads.box_predictor.2.cls_score.{bias, weight}\u001b[0m\n",
+      "\u001b[34mroi_heads.mask_head.predictor.{bias, weight}\u001b[0m\n",
+      "\u001b[34mroi_heads.redshift_fc.0.{bias, weight}\u001b[0m\n",
+      "\u001b[34mroi_heads.redshift_fc.2.{bias, weight}\u001b[0m\n",
+      "\u001b[34mroi_heads.redshift_fc.4.{bias, weight}\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Matching objects\n",
+      "Adding PDFs to ensemble\n",
+      "Adding true Z to ensemble\n",
+      "Writing out this temporary ensemble to disk\n",
+      "Processing chunk (start:end) - (5:10)\n",
+      "\u001b[32m[12/22 18:50:02 d2.checkpoint.detection_checkpoint]: \u001b[0m[DetectionCheckpointer] Loading from /home/shared/hsc/detectron2/projects/ViTDet/model_final_246a82.pkl ...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Skip loading parameter 'backbone.bottom_up.patch_embed.proj.weight' to the model due to incompatible shapes: (128, 3, 4, 4) in the checkpoint but (128, 6, 4, 4) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.box_predictor.0.cls_score.weight' to the model due to incompatible shapes: (81, 1024) in the checkpoint but (2, 1024) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.box_predictor.0.cls_score.bias' to the model due to incompatible shapes: (81,) in the checkpoint but (2,) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.box_predictor.1.cls_score.weight' to the model due to incompatible shapes: (81, 1024) in the checkpoint but (2, 1024) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.box_predictor.1.cls_score.bias' to the model due to incompatible shapes: (81,) in the checkpoint but (2,) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.box_predictor.2.cls_score.weight' to the model due to incompatible shapes: (81, 1024) in the checkpoint but (2, 1024) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.box_predictor.2.cls_score.bias' to the model due to incompatible shapes: (81,) in the checkpoint but (2,) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.mask_head.predictor.weight' to the model due to incompatible shapes: (80, 256, 1, 1) in the checkpoint but (1, 256, 1, 1) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.mask_head.predictor.bias' to the model due to incompatible shapes: (80,) in the checkpoint but (1,) in the model! You might want to double check if this is expected.\n",
+      "Some model parameters or buffers are not found in the checkpoint:\n",
+      "\u001b[34mbackbone.bottom_up.patch_embed.proj.weight\u001b[0m\n",
+      "\u001b[34mroi_heads.box_predictor.0.cls_score.{bias, weight}\u001b[0m\n",
+      "\u001b[34mroi_heads.box_predictor.1.cls_score.{bias, weight}\u001b[0m\n",
+      "\u001b[34mroi_heads.box_predictor.2.cls_score.{bias, weight}\u001b[0m\n",
+      "\u001b[34mroi_heads.mask_head.predictor.{bias, weight}\u001b[0m\n",
+      "\u001b[34mroi_heads.redshift_fc.0.{bias, weight}\u001b[0m\n",
+      "\u001b[34mroi_heads.redshift_fc.2.{bias, weight}\u001b[0m\n",
+      "\u001b[34mroi_heads.redshift_fc.4.{bias, weight}\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Matching objects\n",
+      "Adding PDFs to ensemble\n",
+      "Adding true Z to ensemble\n",
+      "Writing out this temporary ensemble to disk\n",
+      "Inserting handle into data store.  output_DeepDiscEstimatorWithChunks: inprogress_output_DeepDiscEstimatorWithChunks.hdf5, DeepDiscEstimatorWithChunks\n"
+     ]
+    }
+   ],
    "source": [
     "results_from_chunks = EstimatorWithChunks.estimate(test_handle_for_chunks, metadatahandle_with_chunks)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "2e8f2a02-2aec-46cb-b963-c32b3caa0711",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "7"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "res_ens = results_from_chunks.read()\n",
+    "res_ens.npdf"
    ]
   },
   {

--- a/rail_wrap_test.ipynb
+++ b/rail_wrap_test.ipynb
@@ -2,10 +2,19 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "1c2a2dbf",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/drewoldag/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
    "source": [
     "# Training script for LazyConfig models\n",
     "try:\n",
@@ -72,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "5244b7ff-1501-47ad-b74e-c575f9758089",
    "metadata": {},
    "outputs": [],
@@ -87,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "4e82e6de-f6ec-46b5-a6a7-60e79cd79c31",
    "metadata": {},
    "outputs": [],
@@ -106,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "ffd06982-1e98-4b8a-a3a8-b68ac71cd6bc",
    "metadata": {},
    "outputs": [],
@@ -117,15 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c476d78e-9c5d-44a5-9489-de1b9e0d39f1",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "9940c5c2-b692-4e3b-a595-0afec0c21e93",
    "metadata": {},
    "outputs": [],
@@ -138,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "01f48f9e-16a3-423d-a550-ed9298b6fafb",
    "metadata": {},
    "outputs": [],
@@ -153,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "a57e206a-c5c6-4526-a278-868ef2a6047b",
    "metadata": {},
    "outputs": [],
@@ -173,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "d611ae20-a7c7-4f52-9390-1d27eca138f0",
    "metadata": {},
    "outputs": [],
@@ -185,10 +186,95 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "87b6a9d1-697e-4bde-abee-e519253daa6f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Caching data\n",
+      "Training head layers\n",
+      "In launch function\n",
+      "World size: 1\n",
+      "\u001b[32m[12/21 15:39:38 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
+      "\u001b[32m[12/21 15:39:38 d2.data.common]: \u001b[0mSerializing 800 elements to byte tensors and concatenating them all ...\n",
+      "\u001b[32m[12/21 15:40:00 d2.data.common]: \u001b[0mSerialized dataset takes 223.74 MiB\n",
+      "\u001b[32m[12/21 15:40:00 d2.data.build]: \u001b[0mMaking batched data loader with batch_size=1\n",
+      "\u001b[32m[12/21 15:40:00 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
+      "\u001b[32m[12/21 15:40:00 d2.data.common]: \u001b[0mSerializing 200 elements to byte tensors and concatenating them all ...\n",
+      "\u001b[32m[12/21 15:40:04 d2.data.common]: \u001b[0mSerialized dataset takes 55.56 MiB\n",
+      "\u001b[32m[12/21 15:40:22 d2.checkpoint.detection_checkpoint]: \u001b[0m[DetectionCheckpointer] Loading from /home/shared/hsc/detectron2/projects/ViTDet/model_final_246a82.pkl ...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Skip loading parameter 'backbone.bottom_up.patch_embed.proj.weight' to the model due to incompatible shapes: (128, 3, 4, 4) in the checkpoint but (128, 6, 4, 4) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.box_predictor.0.cls_score.weight' to the model due to incompatible shapes: (81, 1024) in the checkpoint but (2, 1024) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.box_predictor.0.cls_score.bias' to the model due to incompatible shapes: (81,) in the checkpoint but (2,) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.box_predictor.1.cls_score.weight' to the model due to incompatible shapes: (81, 1024) in the checkpoint but (2, 1024) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.box_predictor.1.cls_score.bias' to the model due to incompatible shapes: (81,) in the checkpoint but (2,) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.box_predictor.2.cls_score.weight' to the model due to incompatible shapes: (81, 1024) in the checkpoint but (2, 1024) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.box_predictor.2.cls_score.bias' to the model due to incompatible shapes: (81,) in the checkpoint but (2,) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.mask_head.predictor.weight' to the model due to incompatible shapes: (80, 256, 1, 1) in the checkpoint but (1, 256, 1, 1) in the model! You might want to double check if this is expected.\n",
+      "Skip loading parameter 'roi_heads.mask_head.predictor.bias' to the model due to incompatible shapes: (80,) in the checkpoint but (1,) in the model! You might want to double check if this is expected.\n",
+      "Some model parameters or buffers are not found in the checkpoint:\n",
+      "\u001b[34mbackbone.bottom_up.patch_embed.proj.weight\u001b[0m\n",
+      "\u001b[34mroi_heads.box_predictor.0.cls_score.{bias, weight}\u001b[0m\n",
+      "\u001b[34mroi_heads.box_predictor.1.cls_score.{bias, weight}\u001b[0m\n",
+      "\u001b[34mroi_heads.box_predictor.2.cls_score.{bias, weight}\u001b[0m\n",
+      "\u001b[34mroi_heads.mask_head.predictor.{bias, weight}\u001b[0m\n",
+      "\u001b[34mroi_heads.redshift_fc.0.{bias, weight}\u001b[0m\n",
+      "\u001b[34mroi_heads.redshift_fc.2.{bias, weight}\u001b[0m\n",
+      "\u001b[34mroi_heads.redshift_fc.4.{bias, weight}\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m[12/21 15:40:22 d2.engine.train_loop]: \u001b[0mStarting training from iteration 0\n",
+      "<detectron2.solver.lr_scheduler.LRMultiplier object at 0x7ff6b682af70>\n",
+      "Iteration:  5  data time:  0.19410017505288124  loss time:  0.23707077698782086 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.6527390480041504, 0.09666723012924194, 0.5099961757659912, 0.32156988978385925, 0.5019933581352234, 0.6253546476364136, 0.6354149580001831, 0.12217867374420166, 1.8415673971176147, 0.33126288652420044] val loss:  0 lr:  [0.001]\n",
+      "Iteration:  10  data time:  0.12981196399778128  loss time:  0.2137882811948657 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.7394877076148987, 0.22434577345848083, 0.597769558429718, 0.3743278682231903, 0.5623451471328735, 0.4723976254463196, 0.5328865647315979, 0.12546296417713165, 0.6247153878211975, 0.23683761060237885] val loss:  0 lr:  [0.001]\n",
+      "Iteration:  15  data time:  0.2227790467441082  loss time:  0.28334785206243396 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.6638544201850891, 0.2878076732158661, 0.5407952070236206, 0.4644840955734253, 0.5297361612319946, 0.5976332426071167, 0.4481503963470459, 0.13756993412971497, 0.18266184628009796, 0.1945340633392334] val loss:  0 lr:  [0.001]\n",
+      "Iteration:  20  data time:  0.2107845377177  loss time:  0.26004094490781426 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.48777028918266296, 0.19738098978996277, 0.4442472457885742, 0.36665359139442444, 0.4389907121658325, 0.5308727025985718, 0.36784428358078003, 0.12873747944831848, 0.14766791462898254, 0.18052566051483154] val loss:  0 lr:  [0.001]\n",
+      "saving run\n",
+      "Training full model\n",
+      "In launch function\n",
+      "World size: 1\n",
+      "\u001b[32m[12/21 15:40:43 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
+      "\u001b[32m[12/21 15:40:43 d2.data.common]: \u001b[0mSerializing 800 elements to byte tensors and concatenating them all ...\n",
+      "\u001b[32m[12/21 15:41:02 d2.data.common]: \u001b[0mSerialized dataset takes 223.74 MiB\n",
+      "\u001b[32m[12/21 15:41:02 d2.data.build]: \u001b[0mMaking batched data loader with batch_size=1\n",
+      "\u001b[32m[12/21 15:41:02 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
+      "\u001b[32m[12/21 15:41:02 d2.data.common]: \u001b[0mSerializing 200 elements to byte tensors and concatenating them all ...\n",
+      "\u001b[32m[12/21 15:41:03 d2.data.common]: \u001b[0mSerialized dataset takes 55.56 MiB\n",
+      "\u001b[32m[12/21 15:41:13 d2.checkpoint.detection_checkpoint]: \u001b[0m[DetectionCheckpointer] Loading from ./run.pth ...\n",
+      "\u001b[32m[12/21 15:41:13 d2.engine.train_loop]: \u001b[0mStarting training from iteration 0\n",
+      "<detectron2.solver.lr_scheduler.LRMultiplier object at 0x7ff6a3de6790>\n",
+      "Iteration:  5  data time:  0.17509440332651138  loss time:  0.25536190532147884 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5094579458236694, 0.24878017604351044, 0.502326250076294, 0.5008976459503174, 0.4618081748485565, 0.7207968235015869, 0.3495076894760132, 0.1222446858882904, 0.1800243854522705, 0.190628319978714] val loss:  0 lr:  [0.001, 0.001]\n",
+      "Iteration:  10  data time:  0.2070854571647942  loss time:  0.27092082891613245 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5610605478286743, 0.22642430663108826, 0.5160733461380005, 0.46356961131095886, 0.5045719146728516, 0.7461922764778137, 0.37207654118537903, 0.11303846538066864, 0.09658201038837433, 0.17738153040409088] val loss:  0 lr:  [0.001, 0.001]\n",
+      "Iteration:  15  data time:  0.17416224209591746  loss time:  0.2580165406689048 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5428526997566223, 0.3068872392177582, 0.5007061958312988, 0.43888741731643677, 0.4759419560432434, 0.606104850769043, 0.4021938741207123, 0.10056412220001221, 0.17451703548431396, 0.16259533166885376] val loss:  0 lr:  [0.001, 0.001]\n",
+      "Iteration:  20  data time:  0.20399827975779772  loss time:  0.2832088959403336 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5041361451148987, 0.24641898274421692, 0.5174290537834167, 0.38396722078323364, 0.4579388499259949, 0.49565136432647705, 0.3655903935432434, 0.09490177035331726, 0.12687581777572632, 0.1568266898393631] val loss:  0 lr:  [0.001, 0.001]\n",
+      "saving run\n",
+      "Inserting handle into data store.  model_Inform_DeepDISC: inprogress_test_informer.pkl, Inform_DeepDISC\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<rail.core.data.ModelHandle at 0x7ff69d6af970>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Inform.inform(training, metadatahandle)"
    ]
@@ -205,7 +291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "7070dcb2-0de8-42af-af8d-f40c689b7cb1",
    "metadata": {},
    "outputs": [],
@@ -217,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "7360caf2-5b3d-4998-be0c-3ca28fb5e035",
    "metadata": {},
    "outputs": [],
@@ -235,30 +321,63 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "6415a174-6d14-48f5-9241-963a84431501",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "StageConfig{cfgfile:./configs/solo/solo_swin_DC2.py,batch_size:1,output_dir:./,run_name:run,chunk_size:100,num_camera_filters:6,name:DeepDiscEstimator,model:<class 'rail.core.data.ModelHandle'> test_informer.pkl, (wd),epoch:20,num_gpus:1,print_frequency:5,head_epochs:1,full_epochs:1,config:None,input:None,metadata:None,aliases:{'output': 'output_DeepDiscEstimator', 'truth': 'truth_DeepDiscEstimator'},}"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Estimator.config"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "c74bb222-f53c-415c-acab-f8b978a2af5d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Caching data\n",
+      "Matching objects\n",
+      "Inserting handle into data store.  output_DeepDiscEstimator: inprogress_output_DeepDiscEstimator.hdf5, DeepDiscEstimator\n",
+      "Inserting handle into data store.  truth_DeepDiscEstimator: inprogress_truth_DeepDiscEstimator, DeepDiscEstimator\n"
+     ]
+    }
+   ],
    "source": [
     "results = Estimator.estimate(testing, metadatahandle)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "5b402ba2-3779-44e7-8654-113f19731464",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<qp.ensemble.Ensemble at 0x7ff5fc4b68e0>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "res = results.read()\n",
     "res"
@@ -266,7 +385,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "41d2b4a5-0422-4f8f-8e08-49811549c46a",
    "metadata": {},
    "outputs": [],
@@ -276,7 +395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "94da4c4a-93c6-4203-a1b3-4fe186bad242",
    "metadata": {},
    "outputs": [],
@@ -286,14 +405,183 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "f15ba45d-6713-4c63-b153-151c1adc8905",
    "metadata": {
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[0.7432564,\n",
+       " 0.6807421,\n",
+       " 0.40604848,\n",
+       " 0.7111039,\n",
+       " 0.5355953,\n",
+       " 0.0,\n",
+       " 1.2393405,\n",
+       " 0.5530237,\n",
+       " 0.75410193,\n",
+       " 0.0,\n",
+       " 0.5585447,\n",
+       " 1.4091417,\n",
+       " 0.5696309,\n",
+       " 0.56676906,\n",
+       " 1.0360764,\n",
+       " 0.52962214,\n",
+       " 0.7601911,\n",
+       " 0.5831668,\n",
+       " 0.30276734,\n",
+       " 1.3559166,\n",
+       " 1.0675421,\n",
+       " 0.62916094,\n",
+       " 0.22380716,\n",
+       " 1.7364438,\n",
+       " 0.24592146,\n",
+       " 2.6455407,\n",
+       " 1.0246825,\n",
+       " 0.0,\n",
+       " 0.88542485,\n",
+       " 0.93084246,\n",
+       " 0.84799784,\n",
+       " 0.56965196,\n",
+       " 0.44770825,\n",
+       " 0.0,\n",
+       " 0.0,\n",
+       " 1.0113244,\n",
+       " 0.69241905,\n",
+       " 0.27674484,\n",
+       " 0.7931073,\n",
+       " 0.3213708,\n",
+       " 0.81737053,\n",
+       " 1.0199007,\n",
+       " 0.84717727,\n",
+       " 0.0,\n",
+       " 0.39386645,\n",
+       " 0.0,\n",
+       " 2.425019,\n",
+       " 0.5053078,\n",
+       " 1.1667216,\n",
+       " 0.39279625,\n",
+       " 1.3866463,\n",
+       " 0.54890865,\n",
+       " 0.0,\n",
+       " 0.7983657,\n",
+       " 0.38405475,\n",
+       " 0.65973574,\n",
+       " 0.6006085,\n",
+       " 0.060146954,\n",
+       " 0.7484906,\n",
+       " 0.5289882,\n",
+       " 0.42111164,\n",
+       " 0.7728185,\n",
+       " 0.8621007,\n",
+       " 0.69428676,\n",
+       " 0.9497149,\n",
+       " 0.47963572,\n",
+       " 1.16648,\n",
+       " 0.767425,\n",
+       " 0.9695052,\n",
+       " 0.032379486,\n",
+       " 0.559502,\n",
+       " 0.4300901,\n",
+       " 0.637063,\n",
+       " 0.7512283,\n",
+       " 0.3777712,\n",
+       " 0.8552379,\n",
+       " 0.34845287,\n",
+       " 0.0,\n",
+       " 0.0,\n",
+       " 0.39419606,\n",
+       " 0.57076085,\n",
+       " 0.0,\n",
+       " 0.9531508,\n",
+       " 0.0,\n",
+       " 0.7833842,\n",
+       " 0.13510144,\n",
+       " 0.7536498,\n",
+       " 0.5971579,\n",
+       " 1.1287016,\n",
+       " 0.6789744,\n",
+       " 0.8509604,\n",
+       " 0.61471117,\n",
+       " 0.57857525,\n",
+       " 0.95642143,\n",
+       " 0.49101683,\n",
+       " 0.0,\n",
+       " 0.7112921,\n",
+       " 1.6229273]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "ztrue"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d93d6cc-333c-4c28-b5df-f295433cc9e7",
+   "metadata": {},
+   "source": [
+    "## Test new chunking algorithm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "48936320-ed0f-40c3-8329-1f3e2c7c31ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EstimatorWithChunks = DeepDiscPDFEstimatorWithChunking.make_stage(\n",
+    "    name=\"DeepDiscEstimatorWithChunks\",\n",
+    "    model=Inform.get_handle(\"model\"),\n",
+    "    zmin=0,\n",
+    "    zmax=5,\n",
+    "    nzbins=200,\n",
+    "    output_mode='default',\n",
+    "    **deep_dict,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "31f8a0c3-6ad4-430c-9892-b70ae4285ab9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_file_for_chunks = \"/home/shared/hsc/DC2/test_data/dataset_3/flattened_images_test_small.hdf5\"\n",
+    "test_handle_for_chunks = DS.add_data(\"testing\", data=None, handle_class=TableHandle, path=test_file_for_chunks)\n",
+    "metadatafile_with_chunks = \"/home/shared/hsc/DC2/test_data/dataset_3/test_metadata_example.hdf5\"\n",
+    "metadatahandle_with_chunks = DS.add_data(\"metadata\", metadata, Hdf5Handle, path=metadatafile_with_chunks)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c684e258-6c71-476f-bf35-79b53df86282",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results_from_chunks = EstimatorWithChunks.estimate(test_handle_for_chunks, metadatahandle_with_chunks)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bae973cd-8e45-4f70-b12b-2f6dbf01570c",
+   "metadata": {},
+   "source": [
+    "## Evaluation"
    ]
   },
   {

--- a/rail_wrap_test.ipynb
+++ b/rail_wrap_test.ipynb
@@ -2,19 +2,10 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "1c2a2dbf",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/drewoldag/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Training script for LazyConfig models\n",
     "try:\n",
@@ -81,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "5244b7ff-1501-47ad-b74e-c575f9758089",
    "metadata": {},
    "outputs": [],
@@ -96,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "4e82e6de-f6ec-46b5-a6a7-60e79cd79c31",
    "metadata": {},
    "outputs": [],
@@ -115,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "ffd06982-1e98-4b8a-a3a8-b68ac71cd6bc",
    "metadata": {},
    "outputs": [],
@@ -126,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "9940c5c2-b692-4e3b-a595-0afec0c21e93",
    "metadata": {},
    "outputs": [],
@@ -139,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "01f48f9e-16a3-423d-a550-ed9298b6fafb",
    "metadata": {},
    "outputs": [],
@@ -154,13 +145,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
+   "id": "4a89bda8-fd14-4e15-a810-89da7b79f41f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_file_for_chunks = \"/home/shared/hsc/DC2/test_data/dataset_3/flattened_images_test_small.hdf5\"\n",
+    "test_handle_for_chunks = DS.add_data(\"testing\", data=None, handle_class=TableHandle, path=test_file_for_chunks)\n",
+    "metadatafile_with_chunks = \"/home/shared/hsc/DC2/test_data/dataset_3/test_metadata_example.hdf5\"\n",
+    "metadatahandle_with_chunks = DS.add_data(\"metadata\", metadata, Hdf5Handle, path=metadatafile_with_chunks)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "a57e206a-c5c6-4526-a278-868ef2a6047b",
    "metadata": {},
    "outputs": [],
    "source": [
     "deep_dict = dict(\n",
-    "    chunk_size=100,\n",
+    "    chunk_size=5,\n",
     "    epoch=20,\n",
     "    batch_size=1,\n",
     "    output_dir=\"./\",\n",
@@ -174,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "d611ae20-a7c7-4f52-9390-1d27eca138f0",
    "metadata": {},
    "outputs": [],
@@ -186,97 +190,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "87b6a9d1-697e-4bde-abee-e519253daa6f",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Caching data\n",
-      "Training head layers\n",
-      "In launch function\n",
-      "World size: 1\n",
-      "\u001b[32m[12/22 18:41:51 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
-      "\u001b[32m[12/22 18:41:52 d2.data.common]: \u001b[0mSerializing 800 elements to byte tensors and concatenating them all ...\n",
-      "\u001b[32m[12/22 18:42:11 d2.data.common]: \u001b[0mSerialized dataset takes 223.74 MiB\n",
-      "\u001b[32m[12/22 18:42:11 d2.data.build]: \u001b[0mMaking batched data loader with batch_size=1\n",
-      "\u001b[32m[12/22 18:42:11 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
-      "\u001b[32m[12/22 18:42:11 d2.data.common]: \u001b[0mSerializing 200 elements to byte tensors and concatenating them all ...\n",
-      "\u001b[32m[12/22 18:42:15 d2.data.common]: \u001b[0mSerialized dataset takes 55.56 MiB\n",
-      "\u001b[32m[12/22 18:42:35 d2.checkpoint.detection_checkpoint]: \u001b[0m[DetectionCheckpointer] Loading from /home/shared/hsc/detectron2/projects/ViTDet/model_final_246a82.pkl ...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Skip loading parameter 'backbone.bottom_up.patch_embed.proj.weight' to the model due to incompatible shapes: (128, 3, 4, 4) in the checkpoint but (128, 6, 4, 4) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.box_predictor.0.cls_score.weight' to the model due to incompatible shapes: (81, 1024) in the checkpoint but (2, 1024) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.box_predictor.0.cls_score.bias' to the model due to incompatible shapes: (81,) in the checkpoint but (2,) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.box_predictor.1.cls_score.weight' to the model due to incompatible shapes: (81, 1024) in the checkpoint but (2, 1024) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.box_predictor.1.cls_score.bias' to the model due to incompatible shapes: (81,) in the checkpoint but (2,) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.box_predictor.2.cls_score.weight' to the model due to incompatible shapes: (81, 1024) in the checkpoint but (2, 1024) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.box_predictor.2.cls_score.bias' to the model due to incompatible shapes: (81,) in the checkpoint but (2,) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.mask_head.predictor.weight' to the model due to incompatible shapes: (80, 256, 1, 1) in the checkpoint but (1, 256, 1, 1) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.mask_head.predictor.bias' to the model due to incompatible shapes: (80,) in the checkpoint but (1,) in the model! You might want to double check if this is expected.\n",
-      "Some model parameters or buffers are not found in the checkpoint:\n",
-      "\u001b[34mbackbone.bottom_up.patch_embed.proj.weight\u001b[0m\n",
-      "\u001b[34mroi_heads.box_predictor.0.cls_score.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.box_predictor.1.cls_score.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.box_predictor.2.cls_score.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.mask_head.predictor.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.redshift_fc.0.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.redshift_fc.2.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.redshift_fc.4.{bias, weight}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m[12/22 18:42:35 d2.engine.train_loop]: \u001b[0mStarting training from iteration 0\n",
-      "<detectron2.solver.lr_scheduler.LRMultiplier object at 0x7ff69ac26070>\n",
-      "Iteration:  5  data time:  1.0522300801239908  loss time:  0.29681939305737615 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5037013292312622, 0.16843944787979126, 0.7403606176376343, 0.4575991928577423, 0.4938681721687317, 0.6993744373321533, 0.6324691772460938, 0.11370821297168732, 2.002346992492676, 0.3122941851615906] val loss:  0 lr:  [0.001]\n",
-      "Iteration:  10  data time:  0.6905716829933226  loss time:  0.25867572892457247 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.6085929870605469, 0.23859384655952454, 0.5912017822265625, 0.5407350063323975, 0.6333305239677429, 1.2826005220413208, 0.5426815748214722, 0.1298362910747528, 0.8834578990936279, 0.204496830701828] val loss:  0 lr:  [0.001]\n",
-      "Iteration:  15  data time:  1.564404717180878  loss time:  0.4856375381350517 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5638263821601868, 0.3005742132663727, 0.607978880405426, 0.5232330560684204, 0.5338194370269775, 0.5117809176445007, 0.45188355445861816, 0.12964603304862976, 0.2902817130088806, 0.24353452026844025] val loss:  0 lr:  [0.001]\n",
-      "Iteration:  20  data time:  1.3705780040472746  loss time:  0.4064302551560104 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5297995209693909, 0.1727180778980255, 0.5258011817932129, 0.28415346145629883, 0.5042040944099426, 0.43133604526519775, 0.3553069829940796, 0.12488095462322235, 0.182449609041214, 0.1619674563407898] val loss:  0 lr:  [0.001]\n",
-      "saving run\n",
-      "Training full model\n",
-      "In launch function\n",
-      "World size: 1\n",
-      "\u001b[32m[12/22 18:43:20 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
-      "\u001b[32m[12/22 18:43:20 d2.data.common]: \u001b[0mSerializing 800 elements to byte tensors and concatenating them all ...\n",
-      "\u001b[32m[12/22 18:43:43 d2.data.common]: \u001b[0mSerialized dataset takes 223.74 MiB\n",
-      "\u001b[32m[12/22 18:43:43 d2.data.build]: \u001b[0mMaking batched data loader with batch_size=1\n",
-      "\u001b[32m[12/22 18:43:43 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
-      "\u001b[32m[12/22 18:43:43 d2.data.common]: \u001b[0mSerializing 200 elements to byte tensors and concatenating them all ...\n",
-      "\u001b[32m[12/22 18:43:47 d2.data.common]: \u001b[0mSerialized dataset takes 55.56 MiB\n",
-      "\u001b[32m[12/22 18:43:58 d2.checkpoint.detection_checkpoint]: \u001b[0m[DetectionCheckpointer] Loading from ./run.pth ...\n",
-      "\u001b[32m[12/22 18:43:58 d2.engine.train_loop]: \u001b[0mStarting training from iteration 0\n",
-      "<detectron2.solver.lr_scheduler.LRMultiplier object at 0x7ff69af22fa0>\n",
-      "Iteration:  5  data time:  1.0468590259552002  loss time:  0.380195417907089 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.605675220489502, 0.2653862237930298, 0.49304530024528503, 0.3666379153728485, 0.5594156980514526, 0.46857911348342896, 0.39011508226394653, 0.11576427519321442, 0.15428216755390167, 0.1894700527191162] val loss:  0 lr:  [0.001, 0.001]\n",
-      "Iteration:  10  data time:  1.3192340806126595  loss time:  0.4382833302952349 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5601028203964233, 0.3147968649864197, 0.5474895238876343, 0.6594735383987427, 0.480986088514328, 1.2247438430786133, 0.4498133659362793, 0.10091117024421692, 0.10214663296937943, 0.1868215799331665] val loss:  0 lr:  [0.001, 0.001]\n",
-      "Iteration:  15  data time:  1.075973560102284  loss time:  0.38644196512177587 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5816810727119446, 0.23847299814224243, 0.5452905297279358, 0.3061836361885071, 0.4859592020511627, 0.4603598117828369, 0.3550771176815033, 0.09334017336368561, 0.12817241251468658, 0.1598472148180008] val loss:  0 lr:  [0.001, 0.001]\n",
-      "Iteration:  20  data time:  1.3834546231664717  loss time:  0.4178794529289007 dict_keys(['loss_cls_stage0', 'loss_box_reg_stage0', 'loss_cls_stage1', 'loss_box_reg_stage1', 'loss_cls_stage2', 'loss_box_reg_stage2', 'loss_mask', 'redshift_loss', 'loss_rpn_cls', 'loss_rpn_loc']) [0.5129203200340271, 0.2655200958251953, 0.5087618827819824, 0.5217885375022888, 0.478546679019928, 0.5628805160522461, 0.4233054518699646, 0.08892480283975601, 0.07617291808128357, 0.17255885899066925] val loss:  0 lr:  [0.001, 0.001]\n",
-      "saving run\n",
-      "Inserting handle into data store.  model_Inform_DeepDISC: inprogress_test_informer.pkl, Inform_DeepDISC\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<rail.core.data.ModelHandle at 0x7ff69b04c280>"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "Inform.inform(training, metadatahandle)"
+    "# Inform.inform(training, metadatahandle)\n",
+    "Inform.inform(test_handle_for_chunks, metadatahandle_with_chunks) "
    ]
   },
   {
@@ -292,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "7070dcb2-0de8-42af-af8d-f40c689b7cb1",
    "metadata": {},
    "outputs": [],
@@ -304,7 +224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "7360caf2-5b3d-4998-be0c-3ca28fb5e035",
    "metadata": {},
    "outputs": [],
@@ -319,7 +239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "6415a174-6d14-48f5-9241-963a84431501",
    "metadata": {
     "tags": []
@@ -331,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "c74bb222-f53c-415c-acab-f8b978a2af5d",
    "metadata": {},
    "outputs": [],
@@ -341,7 +261,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "5b402ba2-3779-44e7-8654-113f19731464",
    "metadata": {},
    "outputs": [],
@@ -351,7 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "41d2b4a5-0422-4f8f-8e08-49811549c46a",
    "metadata": {},
    "outputs": [],
@@ -361,7 +281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "94da4c4a-93c6-4203-a1b3-4fe186bad242",
    "metadata": {},
    "outputs": [],
@@ -379,7 +299,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "48936320-ed0f-40c3-8329-1f3e2c7c31ac",
    "metadata": {},
    "outputs": [],
@@ -403,7 +323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "31f8a0c3-6ad4-430c-9892-b70ae4285ab9",
    "metadata": {},
    "outputs": [],
@@ -416,112 +336,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "c684e258-6c71-476f-bf35-79b53df86282",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Caching data\n",
-      "Processing chunk (start:end) - (0:5)\n",
-      "\u001b[32m[12/22 18:49:46 d2.checkpoint.detection_checkpoint]: \u001b[0m[DetectionCheckpointer] Loading from /home/shared/hsc/detectron2/projects/ViTDet/model_final_246a82.pkl ...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Skip loading parameter 'backbone.bottom_up.patch_embed.proj.weight' to the model due to incompatible shapes: (128, 3, 4, 4) in the checkpoint but (128, 6, 4, 4) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.box_predictor.0.cls_score.weight' to the model due to incompatible shapes: (81, 1024) in the checkpoint but (2, 1024) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.box_predictor.0.cls_score.bias' to the model due to incompatible shapes: (81,) in the checkpoint but (2,) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.box_predictor.1.cls_score.weight' to the model due to incompatible shapes: (81, 1024) in the checkpoint but (2, 1024) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.box_predictor.1.cls_score.bias' to the model due to incompatible shapes: (81,) in the checkpoint but (2,) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.box_predictor.2.cls_score.weight' to the model due to incompatible shapes: (81, 1024) in the checkpoint but (2, 1024) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.box_predictor.2.cls_score.bias' to the model due to incompatible shapes: (81,) in the checkpoint but (2,) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.mask_head.predictor.weight' to the model due to incompatible shapes: (80, 256, 1, 1) in the checkpoint but (1, 256, 1, 1) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.mask_head.predictor.bias' to the model due to incompatible shapes: (80,) in the checkpoint but (1,) in the model! You might want to double check if this is expected.\n",
-      "Some model parameters or buffers are not found in the checkpoint:\n",
-      "\u001b[34mbackbone.bottom_up.patch_embed.proj.weight\u001b[0m\n",
-      "\u001b[34mroi_heads.box_predictor.0.cls_score.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.box_predictor.1.cls_score.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.box_predictor.2.cls_score.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.mask_head.predictor.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.redshift_fc.0.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.redshift_fc.2.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.redshift_fc.4.{bias, weight}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Matching objects\n",
-      "Adding PDFs to ensemble\n",
-      "Adding true Z to ensemble\n",
-      "Writing out this temporary ensemble to disk\n",
-      "Processing chunk (start:end) - (5:10)\n",
-      "\u001b[32m[12/22 18:50:02 d2.checkpoint.detection_checkpoint]: \u001b[0m[DetectionCheckpointer] Loading from /home/shared/hsc/detectron2/projects/ViTDet/model_final_246a82.pkl ...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Skip loading parameter 'backbone.bottom_up.patch_embed.proj.weight' to the model due to incompatible shapes: (128, 3, 4, 4) in the checkpoint but (128, 6, 4, 4) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.box_predictor.0.cls_score.weight' to the model due to incompatible shapes: (81, 1024) in the checkpoint but (2, 1024) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.box_predictor.0.cls_score.bias' to the model due to incompatible shapes: (81,) in the checkpoint but (2,) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.box_predictor.1.cls_score.weight' to the model due to incompatible shapes: (81, 1024) in the checkpoint but (2, 1024) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.box_predictor.1.cls_score.bias' to the model due to incompatible shapes: (81,) in the checkpoint but (2,) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.box_predictor.2.cls_score.weight' to the model due to incompatible shapes: (81, 1024) in the checkpoint but (2, 1024) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.box_predictor.2.cls_score.bias' to the model due to incompatible shapes: (81,) in the checkpoint but (2,) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.mask_head.predictor.weight' to the model due to incompatible shapes: (80, 256, 1, 1) in the checkpoint but (1, 256, 1, 1) in the model! You might want to double check if this is expected.\n",
-      "Skip loading parameter 'roi_heads.mask_head.predictor.bias' to the model due to incompatible shapes: (80,) in the checkpoint but (1,) in the model! You might want to double check if this is expected.\n",
-      "Some model parameters or buffers are not found in the checkpoint:\n",
-      "\u001b[34mbackbone.bottom_up.patch_embed.proj.weight\u001b[0m\n",
-      "\u001b[34mroi_heads.box_predictor.0.cls_score.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.box_predictor.1.cls_score.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.box_predictor.2.cls_score.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.mask_head.predictor.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.redshift_fc.0.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.redshift_fc.2.{bias, weight}\u001b[0m\n",
-      "\u001b[34mroi_heads.redshift_fc.4.{bias, weight}\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Matching objects\n",
-      "Adding PDFs to ensemble\n",
-      "Adding true Z to ensemble\n",
-      "Writing out this temporary ensemble to disk\n",
-      "Inserting handle into data store.  output_DeepDiscEstimatorWithChunks: inprogress_output_DeepDiscEstimatorWithChunks.hdf5, DeepDiscEstimatorWithChunks\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "results_from_chunks = EstimatorWithChunks.estimate(test_handle_for_chunks, metadatahandle_with_chunks)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "2e8f2a02-2aec-46cb-b963-c32b3caa0711",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "7"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "res_ens = results_from_chunks.read()\n",
     "res_ens.npdf"

--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -407,7 +407,7 @@ class DeepDiscPDFEstimator(CatEstimator):
 class DeepDiscPDFEstimatorWithChunking(CatEstimator):
     """DeepDISC estimator"""
 
-    name = "DeepDiscPDFEstimator"
+    name = "DeepDiscPDFEstimatorWithChunking"
     config_options = {}
     config_options.update(
         cfgfile=Param(str, None, required=True, msg="The primary configuration file for the deepdisc models."),
@@ -459,7 +459,9 @@ class DeepDiscPDFEstimatorWithChunking(CatEstimator):
         is_first = True
 
         print("Caching data")
-        for start_idx, end_idx, images, _, _, metadata_json_dicts in zip(flattened_image_iterator, metadata_iterator):
+        for image_chunk, json_chunk in zip(flattened_image_iterator, metadata_iterator):
+            start_idx, end_idx, images = image_chunk
+            _, _, metadata_json_dicts = json_chunk
 
             # Convert the json into dicts and load them into a list
             metadata = [json.loads(this_json) for this_json in metadata_json_dicts['metadata_dicts']]

--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -427,8 +427,7 @@ class DeepDiscPDFEstimatorWithChunking(CatEstimator):
     inputs = [("model", ModelHandle),
               ("input", TableHandle),
               ("metadata", Hdf5Handle)]
-    outputs = [("output", QPHandle),
-               ("truth", TableHandle)]
+    outputs = [("output", QPHandle)]
 
     def __init__(self, args, comm=None):
         """Constructor:
@@ -566,30 +565,6 @@ class DeepDiscPDFEstimatorWithChunking(CatEstimator):
             self._do_chunk_output(qp_dstn, previous_index, previous_index + meta.total_pdfs, is_first)
             previous_index += meta.total_pdfs
             is_first = False
-
-        # # make a special exception for the very first temporary file
-        # # for anyone looking, this is awful. I'm sorry.
-        # meta = self._temp_file_meta_tuples[0]
-        # tmp_handle = meta.file_handle
-        # qp_dstn = tmp_handle.read()
-        # self._output_handle = self.add_handle('output', data=qp_dstn)
-        # self._output_handle.initialize_write(total_pdfs, communicator=self.comm)
-        # self._output_handle.set_data(qp_dstn, partial=True)
-        # self._output_handle.write_chunk(0, meta.total_pdfs)
-
-        # # loop over the remaining temporary files and insert them into the new QPHandle
-        # previous_index = meta.total_pdfs
-        # for meta in self._temp_file_meta_tuples[1:]:
-        #     if meta.total_pdfs == 0:
-        #         continue
-        #     tmp_handle = meta.file_handle
-        #     qp_dstn = tmp_handle.read()
-        #     self._output_handle.set_data(qp_dstn, partial=True)
-        #     self._output_handle.write_chunk(previous_index, previous_index + meta.total_pdfs)
-        #     previous_index += meta.total_pdfs
-
-        # finalize the new QPHandle
-        self._output_handle.finalize_write()
 
         # call the super class to finalize any parallelization work happening
         PipelineStage.finalize(self)

--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -513,9 +513,8 @@ class DeepDiscPDFEstimatorWithChunking(CatEstimator):
             lambda dataset_dict: dataset_dict["filename"],
             self.predictor,
         )
-        self.true_zs = true_zs
-        self.pdfs = np.array(pdfs)
-        num_pdfs = len(self.pdfs)
+        pdfs = np.array(pdfs)
+        num_pdfs = len(pdfs)
 
         # don't write out if no pdfs are returned from the model
         if num_pdfs == 0:
@@ -524,9 +523,9 @@ class DeepDiscPDFEstimatorWithChunking(CatEstimator):
 
         # add this chunk of pdfs to a qp.ensemble
         print("Adding PDFs to ensemble")
-        qp_dstn = qp.Ensemble(qp.interp, data=dict(xvals=self.zgrid, yvals=self.pdfs))
+        qp_dstn = qp.Ensemble(qp.interp, data=dict(xvals=self.zgrid, yvals=pdfs))
         print("Adding true Z to ensemble")
-        qp_dstn.set_ancil(dict(true_zs=self.true_zs))
+        qp_dstn.set_ancil(dict(true_zs=true_zs))
 
         # calculate point estimates and save them in ancil data
         qp_dstn = self.calculate_point_estimates(qp_dstn)
@@ -537,7 +536,9 @@ class DeepDiscPDFEstimatorWithChunking(CatEstimator):
         )
 
     def _write_temp_file(self, qp_dstn, start_idx, num_pdfs):
-        """Write the qp.ensemble to a temporary file and return the handle.
+        """Write the qp.ensemble to a temporary file and return a named tuple
+        that contains the start index, file name, total number of pdfs, and data
+        handle for the temporary file.
 
         Parameters
         ----------

--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -30,7 +30,7 @@ from detectron2.config import LazyConfig, get_cfg, instantiate, CfgNode
 from detectron2.engine import launch
 from detectron2.engine.defaults import create_ddp_model
 from rail.core.common_params import SHARED_PARAMS
-from rail.core.data import Hdf5Handle, ModelHandle, QPHandle, TableHandle
+from rail.core.data import Hdf5Handle, JsonHandle, ModelHandle, QPHandle, TableHandle
 from rail.estimation.estimator import CatEstimator, CatInformer
 
 
@@ -208,7 +208,7 @@ class DeepDiscInformer(CatInformer):
                 this_image_metadata["filename"] = file_path
 
             # add this chunk of metadata to the list of metadata
-            self.metadata.append(metadata_chunk)
+            self.metadata.extend(metadata_chunk)
 
         dist_url = self._get_dist_url()
 


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
This PR represents the work to chunk the input metadata in the evaluation stage. The assumption is that the metadata is provided as an HDF5 file where each record in the file is a json string representing a metadata dictionary for an image. 

We will read in the appropriate number of images and JSON records from the HDF5 file then reshape the images for caching, and convert the JSON records to a list of dictionaries. The list of dicts will be passed to deepdisc for inference, and a qp Ensemble containing the results will be written to a temporary file. 

All the temporary files and their corresponding image indexes are as named tuples in the list `self._temp_file_meta_tuples`. 

In the `finalize` method, we sort the list of named tuples by starting index, calculate the total number of PDFs in all the temp files, initialize an output file of the appropriate size, then write the contents of each temp file to the final file. 

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
