### PR TITLE
add matched_ids

### DIFF
--- a/configs/solo/solo_swin_DC2.py
+++ b/configs/solo/solo_swin_DC2.py
@@ -49,7 +49,7 @@ model.pixel_std = [
 ]
 
 model.roi_heads.num_components = 1
-#model.roi_heads.zloss_factor = 1
+model.roi_heads.zloss_factor = 0.1
 model.roi_heads._target_ = RedshiftPDFCasROIHeads
 model.proposal_generator.nms_thresh = 0.3
 

--- a/rail_wrap_test.ipynb
+++ b/rail_wrap_test.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "1c2a2dbf",
    "metadata": {},
    "outputs": [],
@@ -73,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "5244b7ff-1501-47ad-b74e-c575f9758089",
    "metadata": {},
    "outputs": [],
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "4e82e6de-f6ec-46b5-a6a7-60e79cd79c31",
    "metadata": {},
    "outputs": [],
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "ffd06982-1e98-4b8a-a3a8-b68ac71cd6bc",
    "metadata": {},
    "outputs": [],
@@ -118,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "01f48f9e-16a3-423d-a550-ed9298b6fafb",
    "metadata": {},
    "outputs": [],
@@ -134,20 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "4a89bda8-fd14-4e15-a810-89da7b79f41f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#test_file_for_chunks = \"/home/shared/hsc/DC2/test_data/dataset_3/flattened_images_test_small.hdf5\"\n",
-    "#test_handle_for_chunks = DS.add_data(\"testing\", data=None, handle_class=TableHandle, path=test_file_for_chunks)\n",
-    "#metadatafile_with_chunks = \"/home/shared/hsc/DC2/test_data/dataset_3/test_metadata_example.hdf5\"\n",
-    "#metadatahandle_with_chunks = DS.add_data(\"metadata\", metadata, Hdf5Handle, path=metadatafile_with_chunks)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "a57e206a-c5c6-4526-a278-868ef2a6047b",
    "metadata": {},
    "outputs": [],
@@ -159,15 +146,15 @@
     "    output_dir=\"./\",\n",
     "    cfgfile = cfgfile,\n",
     "    num_gpus=1,\n",
-    "    print_frequency=5,\n",
-    "    head_epochs=1,\n",
-    "    full_epochs=1,\n",
+    "    print_frequency=10,\n",
+    "    head_epochs=3,\n",
+    "    full_epochs=3,\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "d611ae20-a7c7-4f52-9390-1d27eca138f0",
    "metadata": {},
    "outputs": [],
@@ -279,87 +266,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "e48290de-6f18-422c-9b04-c6aaec97439f",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from rail.core.data import ModelHandle"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "8c712fc8-1e60-4389-86fb-2864922fe19f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "MH = ModelHandle('model',path='./test_informer.pkl')\n",
-    "data = MH.read()\n",
-    "#MH()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "6d5c4f6f-2929-4653-b89c-29c94aae92c1",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cfgfile = \"./configs/solo/solo_swin_DC2.py\"\n",
-    "cfg = LazyConfig.load(cfgfile)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "26bfb59c-5bbc-42c3-b320-7bef7386cc47",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#MH()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "5d7cfa05-5bcf-45dc-b1f1-fb25128da2d0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "checkpoint = MH()['nnmodel']"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "610c2806-5bb6-4781-afd0-1c122199877d",
+   "id": "8c712fc8-1e60-4389-86fb-2864922fe19f",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "#checkpoint=Inform.get_handle(\"model\")\n",
-    "#help(checkpoint)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "id": "58934320-d950-49e0-b2af-0c9b2e21cb09",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "checkpoint\n"
-     ]
-    }
-   ],
-   "source": [
-    "#predictor = return_predictor_transformer(cfg, checkpoint=checkpoint)\n",
-    "import deepdisc.astrodet.astrodet as toolkit\n",
-    "predictor = toolkit.AstroPredictor(cfg,checkpoint=checkpoint)"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
@@ -367,7 +286,24 @@
    "id": "1a243e22-46b1-47a2-9c31-9e0746dbee7a",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "#from rail.core.data import ModelHandle\n",
+    "MH = ModelHandle('model',path='./test_informer.pkl')\n",
+    "data = MH.read()\n",
+    "#cfgfile = \"./configs/solo/solo_swin_DC2.py\"\n",
+    "#cfg = LazyConfig.load(cfgfile)\n",
+    "#checkpoint = MH()['nnmodel']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15fb9820-e604-4fff-95ba-c549311ebd7f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#data"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -379,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "48936320-ed0f-40c3-8329-1f3e2c7c31ac",
    "metadata": {},
    "outputs": [],
@@ -392,6 +328,7 @@
     "    zmax=5,\n",
     "    nzbins=200,\n",
     "    output_mode='default',\n",
+    "    include_ids=True\n",
     ")\n",
     "\n",
     "EstimatorWithChunks = DeepDiscPDFEstimatorWithChunking.make_stage(\n",
@@ -404,7 +341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "31f8a0c3-6ad4-430c-9892-b70ae4285ab9",
    "metadata": {},
    "outputs": [],
@@ -417,29 +354,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "c684e258-6c71-476f-bf35-79b53df86282",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Inserting handle into data store.  model: ./test_informer.pkl, DeepDiscEstimatorWithChunks\n",
-      "checkpoint\n",
-      "Caching data\n",
-      "Processing chunk (start:end) - (0:5)\n",
-      "Matching objects\n",
-      "No PDFs returned from the model, skipping this chunk\n",
-      "Processing chunk (start:end) - (5:10)\n",
-      "Matching objects\n",
-      "Adding PDFs to ensemble\n",
-      "Adding true Z to ensemble\n",
-      "Writing out this temporary ensemble to disk\n",
-      "Inserting handle into data store.  output_DeepDiscEstimatorWithChunks: inprogress_output_DeepDiscEstimatorWithChunks.hdf5, DeepDiscEstimatorWithChunks\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "results_from_chunks = EstimatorWithChunks.estimate(test_handle_for_chunks, metadatahandle_with_chunks)"
    ]
@@ -458,11 +376,53 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b1a8f659-bc35-47d0-abd4-f0a662330a7a",
+   "id": "57dee5cd-d2ad-4132-83a9-3845aeb8bbd6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "res_ens"
+    "res_ens.ancil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac614133-deb4-4fd6-be40-ed5750ff13e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output = EstimatorWithChunks.get_handle(\"output\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d1513a0-2297-4c6c-807a-83faa995bad5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output.data.ancil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "071207a1-b3cf-4b99-9367-7df45f2073c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dtest = np.arange(9)\n",
+    "output.data.add_to_ancil(dict(ids=dtest))\n",
+    "output.data.ancil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2b87871-e04b-4bb1-9d51-200fe3663b9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#help(output.data)"
    ]
   },
   {

--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -278,13 +278,15 @@ class DeepDiscPDFEstimator(CatEstimator):
         run_name=Param(str, "run", required=False, msg="Name of the training run."),
         chunk_size=Param(int, 100, required=False, msg="Chunk size used within detectron2 code."),
         num_camera_filters=Param(int, 6, required=False, msg="The number of camera filters for the dataset used (LSST has 6)."),
+        calculated_point_estimates=Param(list, ['mode'], required=False, msg="The point estimates to include by default."),
+        include_ids=Param(bool, False, required=False, msg="Include object IDs in QP ensemble."),
+
     )
 
     inputs = [("model", ModelHandle),
               ("input", TableHandle),
               ("metadata", JsonHandle)]
     outputs = [("output", QPHandle),
-               ("truth", TableHandle)]
 
     def __init__(self, args, comm=None):
         """Constructor:
@@ -339,14 +341,18 @@ class DeepDiscPDFEstimator(CatEstimator):
         self.predictor = return_predictor_transformer(cfg, checkpoint=self.nnmodel)
 
         print("Matching objects")
-        true_zs, pdfs = get_matched_z_pdfs(
+        true_zs, pdfs, matched_ids = get_matched_z_pdfs(
             metadata,
             DC2ImageReader(),
             lambda dataset_dict: dataset_dict["filename"],
             self.predictor,
+            self.config.include_ids
+
         )
-        self.true_zs = true_zs
+        self.true_zs = np.array(true_zs)
         self.pdfs = np.array(pdfs)
+        if self.include_ids:
+            self.matched_ids = np.array(matched_ids)
 
     def finalize(self):
         self.zgrid = np.linspace(0, 5, 200)
@@ -355,9 +361,12 @@ class DeepDiscPDFEstimator(CatEstimator):
         qp_distn = qp.Ensemble(qp.interp, data=dict(xvals=self.zgrid, yvals=self.pdfs))
         qp_distn.set_ancil(dict(zmode=zmode))
         qp_distn = self.calculate_point_estimates(qp_distn)
+        qp_dstn.add_to_ancil(dict(true_zs=self.true_zs))
+        if self.include_ids:
+            qp_dstn.add_to_ancil(dict(ids=self.matched_ids))
+
         self.add_handle("output", data=qp_distn)
-        truth_dict = dict(redshift=self.true_zs)
-        self.add_handle("truth", data=truth_dict)
+
 
 
 class DeepDiscPDFEstimatorWithChunking(CatEstimator):
@@ -373,6 +382,8 @@ class DeepDiscPDFEstimatorWithChunking(CatEstimator):
         chunk_size=Param(int, 100, required=False, msg="Chunk size used within detectron2 code."),
         num_camera_filters=Param(int, 6, required=False, msg="The number of camera filters for the dataset used (LSST has 6)."),
         calculated_point_estimates=Param(list, ['mode'], required=False, msg="The point estimates to include by default."),
+        include_ids=Param(bool, False, required=False, msg="Include object IDs in QP ensemble."),
+
     )
 
     inputs = [("model", ModelHandle),
@@ -457,12 +468,15 @@ class DeepDiscPDFEstimatorWithChunking(CatEstimator):
         """
 
         print("Matching objects")
-        true_zs, pdfs = get_matched_z_pdfs(
+
+        true_zs, pdfs, matched_ids = get_matched_z_pdfs(
             metadata,
             DC2ImageReader(),
             lambda dataset_dict: dataset_dict["filename"],
             self.predictor,
+            self.config.include_ids
         )
+
         pdfs = np.array(pdfs)
         num_pdfs = len(pdfs)
 
@@ -474,11 +488,16 @@ class DeepDiscPDFEstimatorWithChunking(CatEstimator):
         # add this chunk of pdfs to a qp.ensemble
         print("Adding PDFs to ensemble")
         qp_dstn = qp.Ensemble(qp.interp, data=dict(xvals=self.zgrid, yvals=pdfs))
-        print("Adding true Z to ensemble")
-        qp_dstn.set_ancil(dict(true_zs=true_zs))
 
         # calculate point estimates and save them in ancil data
         qp_dstn = self.calculate_point_estimates(qp_dstn)
+        
+        print("Adding true Z to ensemble")
+        qp_dstn.add_to_ancil(dict(true_zs=np.array(true_zs)))
+
+        if self.config.include_ids:
+            print("Adding object IDs to ensemble")
+            qp_dstn.add_to_ancil(dict(ids=np.array(matched_ids)))   
 
         # write out the temp file and track it
         self._temp_file_meta_tuples.append(


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
This adds matched object IDs to the ancillary data of the QPEnsemble output of the Estimator.  Users can specify to include these with the include_ids flag in the stage config dicts

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
