### PR TITLE
Adding check in Informer __init__ for batch_size/num_gpu compatibility

### DIFF
--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -163,7 +163,7 @@ class DeepDiscInformer(CatInformer):
         print_frequency=Param(int, 5, required=False, msg="How often to print in-progress output (happens every x number of iterations)."),
         head_epochs=Param(int, 0, required=False, msg="How many iterations when training the head layers (while the backbone layers are frozen)."),
         full_epochs=Param(int, 0, required=False, msg="How many iterations when training the head layers and unfrozen backbone layers together."),
-        num_gpus=Param(int, 4, required=False, msg="Number of processes per machine. When using GPUs, this should be the number of GPUs."),
+        num_gpus=Param(int, 1, required=False, msg="Number of processes per machine. When using GPUs, this should be the number of GPUs."),
         num_machines=Param(int, 1, required=False, msg="The total number of machines."),
         machine_rank=Param(int, 0, required=False, msg="The rank of this machine."),
     )
@@ -171,6 +171,10 @@ class DeepDiscInformer(CatInformer):
 
     def __init__(self, args, comm=None):
         CatInformer.__init__(self, args, comm=comm)
+
+        # check to make sure that batch_size is an even multiple of num_gpus
+        if self.config.batch_size % self.config.num_gpus != 0:
+            raise ValueError(f"batch_size ({self.config.batch_size}) must be an even multiple of num_gpus ({self.config.num_gpus})")
 
     def inform(self, input_data, input_metadata):
         with tempfile.TemporaryDirectory() as temp_directory_name:

--- a/tests/deepdisc/test_informer.py
+++ b/tests/deepdisc/test_informer.py
@@ -1,0 +1,38 @@
+import pytest
+from rail.estimation.algos.deepdisc import DeepDiscInformer
+
+def test_basic_informer_stage_creation():
+    """A simple test to make sure that the Informer stage can be created"""
+
+    deep_dict = dict(
+        cfgfile = './foo.txt',
+        batch_size=4,
+        num_gpus=2,
+    )
+
+    informer_stage = DeepDiscInformer.make_stage(
+        name="foo_DeepDISC",
+        model="output_informer_model.pkl",
+        **deep_dict
+    )
+
+    assert informer_stage.name == "DeepDiscInformer"
+
+
+def test_batch_and_num_gpus_mismatch():
+    """Test that an error is raised if batch_size is not an even multiple of num_gpus"""
+
+    deep_dict = dict(
+        cfgfile = './foo.txt',
+        batch_size=5,
+        num_gpus=2,
+    )
+
+    with pytest.raises(ValueError) as exc:
+        _ = DeepDiscInformer.make_stage(
+            name="Inform_DeepDISC",
+            model="test_informer.pkl",
+            **deep_dict
+        )
+
+    assert "must be an even multiple of num_gpus" in str(exc.value)


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
Addresses issue #49 
This work adds a check to make sure that batch_size and num_gpu are compatible. If batch_size is not an even multiple of num_gpus then pytorch (or detectron???) will throw an error. But it takes a long time to get to that error. I've included the check in the init function so that the user will know almost immediately. 

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
