### PR TITLE
Use multiprocess.Manager for Queue

### DIFF
--- a/estimation_stage_only.ipynb
+++ b/estimation_stage_only.ipynb
@@ -5,16 +5,7 @@
    "execution_count": 1,
    "id": "d614d238-437b-44f0-99da-4c710e2f8309",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/drewoldag/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import rail\n",
     "from rail.estimation.algos.deepdisc import *\n",
@@ -97,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "4bb55a78-337b-4af9-8804-436873a54074",
    "metadata": {},
    "outputs": [
@@ -105,7 +96,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/drewoldag/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/torch/functional.py:504: UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument. (Triggered internally at /data/miniconda3/envs/opence-1.7/conda-bld/pytorch-base_1672876060819/work/aten/src/ATen/native/TensorShape.cpp:3190.)\n",
+      "/home/g4merz/.conda/envs/ddrailnv/lib/python3.9/site-packages/torch/functional.py:504: UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument. (Triggered internally at /data/miniconda3/envs/opence-1.7/conda-bld/pytorch-base_1672876060819/work/aten/src/ATen/native/TensorShape.cpp:3190.)\n",
       "  return _VF.meshgrid(tensors, **kwargs)  # type: ignore[attr-defined]\n"
      ]
     },
@@ -114,46 +105,21 @@
      "output_type": "stream",
      "text": [
       "Caching data\n",
-      "Processing chunk (start:end) - (0:5)\n",
-      "\u001b[32m[01/17 18:56:24 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
-      "\u001b[32m[01/17 18:56:24 d2.data.common]: \u001b[0mSerializing 5 elements to byte tensors and concatenating them all ...\n",
-      "\u001b[32m[01/17 18:56:24 d2.data.common]: \u001b[0mSerialized dataset takes 1.29 MiB\n",
-      "\u001b[32m[01/17 18:56:24 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
-      "\u001b[32m[01/17 18:56:24 d2.data.common]: \u001b[0mSerializing 5 elements to byte tensors and concatenating them all ...\n",
-      "\u001b[32m[01/17 18:56:24 d2.data.common]: \u001b[0mSerialized dataset takes 1.29 MiB\n"
+      "Processing chunk (start:end) - (0:5)\n"
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/drewoldag/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/torch/functional.py:504: UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument. (Triggered internally at /data/miniconda3/envs/opence-1.7/conda-bld/pytorch-base_1672876060819/work/aten/src/ATen/native/TensorShape.cpp:3190.)\n",
-      "  return _VF.meshgrid(tensors, **kwargs)  # type: ignore[attr-defined]\n",
-      "/home/drewoldag/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/torch/functional.py:504: UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument. (Triggered internally at /data/miniconda3/envs/opence-1.7/conda-bld/pytorch-base_1672876060819/work/aten/src/ATen/native/TensorShape.cpp:3190.)\n",
-      "  return _VF.meshgrid(tensors, **kwargs)  # type: ignore[attr-defined]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Processing chunk (start:end) - (5:10)\n",
-      "\u001b[32m[01/17 18:57:12 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
-      "\u001b[32m[01/17 18:57:12 d2.data.common]: \u001b[0mSerializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>\n",
-      "\u001b[32m[01/17 18:57:12 d2.data.common]: \u001b[0mSerializing 5 elements to byte tensors and concatenating them all ...\n",
-      "\u001b[32m[01/17 18:57:12 d2.data.common]: \u001b[0mSerializing 5 elements to byte tensors and concatenating them all ...\n",
-      "\u001b[32m[01/17 18:57:12 d2.data.common]: \u001b[0mSerialized dataset takes 1.37 MiB\n",
-      "\u001b[32m[01/17 18:57:12 d2.data.common]: \u001b[0mSerialized dataset takes 1.37 MiB\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/drewoldag/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/torch/functional.py:504: UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument. (Triggered internally at /data/miniconda3/envs/opence-1.7/conda-bld/pytorch-base_1672876060819/work/aten/src/ATen/native/TensorShape.cpp:3190.)\n",
-      "  return _VF.meshgrid(tensors, **kwargs)  # type: ignore[attr-defined]\n",
-      "/home/drewoldag/.conda/envs/rail_deepdisc39/lib/python3.9/site-packages/torch/functional.py:504: UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument. (Triggered internally at /data/miniconda3/envs/opence-1.7/conda-bld/pytorch-base_1672876060819/work/aten/src/ATen/native/TensorShape.cpp:3190.)\n",
-      "  return _VF.meshgrid(tensors, **kwargs)  # type: ignore[attr-defined]\n"
+     "ename": "AttributeError",
+     "evalue": "module 'torch.multiprocessing' has no attribute 'Mananger'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[6], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m results_from_chunks \u001b[38;5;241m=\u001b[39m \u001b[43mEstimatorWithChunks\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mestimate\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtest_handle_for_chunks\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmetadatahandle_with_chunks\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/rail_deepdisc/src/rail/estimation/algos/deepdisc.py:477\u001b[0m, in \u001b[0;36mDeepDiscPDFEstimatorWithChunking.estimate\u001b[0;34m(self, input_data, input_metadata)\u001b[0m\n\u001b[1;32m    475\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mset_data(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124minput\u001b[39m\u001b[38;5;124m\"\u001b[39m, input_data)\n\u001b[1;32m    476\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mset_data(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmetadata\u001b[39m\u001b[38;5;124m\"\u001b[39m, input_metadata)\n\u001b[0;32m--> 477\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    478\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mfinalize()\n\u001b[1;32m    479\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mget_handle(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124moutput\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
+      "File \u001b[0;32m~/rail_deepdisc/src/rail/estimation/algos/deepdisc.py:528\u001b[0m, in \u001b[0;36mDeepDiscPDFEstimatorWithChunking.run\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    526\u001b[0m \u001b[38;5;66;03m# process this chunk of data\u001b[39;00m\n\u001b[1;32m    527\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mProcessing chunk (start:end) - (\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mstart_idx\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m:\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mend_idx\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m)\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m--> 528\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_process_chunk\u001b[49m\u001b[43m(\u001b[49m\u001b[43mstart_idx\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmetadata\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/rail_deepdisc/src/rail/estimation/algos/deepdisc.py:542\u001b[0m, in \u001b[0;36mDeepDiscPDFEstimatorWithChunking._process_chunk\u001b[0;34m(self, start_idx, metadata)\u001b[0m\n\u001b[1;32m    530\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m_process_chunk\u001b[39m(\u001b[38;5;28mself\u001b[39m, start_idx, metadata):\n\u001b[1;32m    531\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"For a given block of images and metadata, calculate the PDFs and\u001b[39;00m\n\u001b[1;32m    532\u001b[0m \u001b[38;5;124;03m    write them to a temporary file.\u001b[39;00m\n\u001b[1;32m    533\u001b[0m \n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    539\u001b[0m \u001b[38;5;124;03m        The list of metadata dictionaries for this block of images\u001b[39;00m\n\u001b[1;32m    540\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 542\u001b[0m     \u001b[38;5;28;01mwith\u001b[39;00m \u001b[43mmp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mMananger\u001b[49m() \u001b[38;5;28;01mas\u001b[39;00m manager:\n\u001b[1;32m    543\u001b[0m         q \u001b[38;5;241m=\u001b[39m manager\u001b[38;5;241m.\u001b[39mQueue()\n\u001b[1;32m    545\u001b[0m         \u001b[38;5;66;03m# call detectron2's `launch` function to parallelize the inference\u001b[39;00m\n",
+      "\u001b[0;31mAttributeError\u001b[0m: module 'torch.multiprocessing' has no attribute 'Mananger'"
      ]
     }
    ],
@@ -250,9 +216,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:.conda-rail_deepdisc39]",
+   "display_name": "Python [conda env:.conda-ddrailnv]",
    "language": "python",
-   "name": "conda-env-.conda-rail_deepdisc39-py"
+   "name": "conda-env-.conda-ddrailnv-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -539,36 +539,37 @@ class DeepDiscPDFEstimatorWithChunking(CatEstimator):
             The list of metadata dictionaries for this block of images
         """
 
-        q = mp.Queue()
+        with mp.Mananger() as manager:
+            q = manager.Queue()
 
-        # call detectron2's `launch` function to parallelize the inference
-        launch(
-            _do_inference,
-            num_gpus_per_machine=self.config.num_gpus,
-            # num_machines=1 ??? I don't think we need this
-            # machine_rank=self.rank ??? I don't think we need this, I could be wrong
-            dist_url=_get_dist_url(),
-            args=(
-                q,
-                self.predictor,
-                metadata,
-                self.config.num_gpus,
-                self.config.batch_size,
-                self.zgrid,
-                self.config.return_ids_with_inference,
-            ),
-        )
+            # call detectron2's `launch` function to parallelize the inference
+            launch(
+                _do_inference,
+                num_gpus_per_machine=self.config.num_gpus,
+                # num_machines=1 ??? I don't think we need this
+                # machine_rank=self.rank ??? I don't think we need this, I could be wrong
+                dist_url=_get_dist_url(),
+                args=(
+                    q,
+                    self.predictor,
+                    metadata,
+                    self.config.num_gpus,
+                    self.config.batch_size,
+                    self.zgrid,
+                    self.config.return_ids_with_inference,
+                ),
+            )
 
-        # Check the queue and grab the qp.ensemble if it's there
-        if q.qsize():
-            qp_dstn = q.get()
+            # Check the queue and grab the qp.ensemble if it's there
+            if q.qsize():
+                qp_dstn = q.get()
 
-            # if there are pdfs in the qp.ensemble, calculate point estimates and
-            # write the qp.ensemble to a temporary file.
-            if qp_dstn is not None and qp_dstn.npdf:
-                qp_dstn = self.calculate_point_estimates(qp_dstn)
-                temp_file_tuple = self._write_temp_file(qp_dstn, start_idx)
-                self._temp_file_meta_tuples.append(temp_file_tuple)
+                # if there are pdfs in the qp.ensemble, calculate point estimates and
+                # write the qp.ensemble to a temporary file.
+                if qp_dstn is not None and qp_dstn.npdf:
+                    qp_dstn = self.calculate_point_estimates(qp_dstn)
+                    temp_file_tuple = self._write_temp_file(qp_dstn, start_idx)
+                    self._temp_file_meta_tuples.append(temp_file_tuple)
 
 
     def _write_temp_file(self, qp_dstn, start_idx):

--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -539,7 +539,7 @@ class DeepDiscPDFEstimatorWithChunking(CatEstimator):
             The list of metadata dictionaries for this block of images
         """
 
-        with mp.Mananger() as manager:
+        with mp.Manager() as manager:
             q = manager.Queue()
 
             # call detectron2's `launch` function to parallelize the inference


### PR DESCRIPTION
Using multiprocessing manager.Queue instead of bare Queue to avoid deadlock.

## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
