### PR TITLE
Clarify `batch_size` and `chunk_size` stage parameters

### DIFF
--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -158,7 +158,7 @@ class DeepDiscInformer(CatInformer):
     config_options.update(
         cfgfile=Param(str, None, required=True, msg="The primary configuration file for the deepdisc models."),
 
-        batch_size=Param(int, 1, required=False, msg="Number of images sent to each GPU per node for parallel training."),
+        batch_size=Param(int, 1, required=False, msg="Number of images sent to all GPUs per node for parallel training.  Must be divisible by the number of GPUs per node"),
         chunk_size=Param(int, 100, required=False, msg="Number of images distributed to each node for training."), #??? [Drew] I'm pretty confident we don't need to define this.
         epoch=Param(int, 20, required=False, msg="Number of iterations per epooch."),
         full_epochs=Param(int, 0, required=False, msg="How many iterations when training the head layers and unfrozen backbone layers together."),

--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -158,8 +158,7 @@ class DeepDiscInformer(CatInformer):
     config_options.update(
         cfgfile=Param(str, None, required=True, msg="The primary configuration file for the deepdisc models."),
 
-        batch_size=Param(int, 1, required=False, msg="Number of images sent to all GPUs per node for parallel training.  Must be divisible by the number of GPUs per node"),
-        chunk_size=Param(int, 100, required=False, msg="Number of images distributed to each node for training."), #??? [Drew] I'm pretty confident we don't need to define this.
+        batch_size=Param(int, 1, required=False, msg="Number of images sent to each GPU per node for parallel training."),
         epoch=Param(int, 20, required=False, msg="Number of iterations per epooch."),
         full_epochs=Param(int, 0, required=False, msg="How many iterations when training the head layers and unfrozen backbone layers together."),
         head_epochs=Param(int, 0, required=False, msg="How many iterations when training the head layers (while the backbone layers are frozen)."),

--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -170,7 +170,7 @@ class DeepDiscInformer(CatInformer):
         output_dir=Param(str, "./", required=False, msg="The directory to write output to."),
         print_frequency=Param(int, 5, required=False, msg="How often to print in-progress output (happens every x number of iterations)."),
         run_name=Param(str, "run", required=False, msg="Name of the training run."),
-        training_percent=Param(float, 0.8, required=False, msg="The fraction of input data used to split into training/evaluation sets"),
+        training_percent=Param(float, 0.8, required=False, msg="The fraction of input data used to split into training/evaluation sets."),
     )
     inputs = [('input', TableHandle), ('metadata', Hdf5Handle)]
 


### PR DESCRIPTION


## Problem & Solution Description (including issue #)
This addresses issue #62 
Attempted to clarify the meaning of `batch_size` and `chunk_size` in the StageParam definitions so that help messages will be more clear.
Added more docstring explanation to the Informer and Estimator stages.
Ordered the Informer and Estimator StageParams by `required`, then alphabetically.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
