### PR TITLE
Update for ceci version 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "pz-rail-base>=1.0.3",
+    "pz-rail-base",
     "deepdisc@git+https://github.com/lincc-frameworks/deepdisc.git",
     "detectron2@git+https://github.com/facebookresearch/detectron2.git",
     "scarlet@git+https://github.com/pmelchior/scarlet.git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
+    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
     "deepdisc@git+https://github.com/lincc-frameworks/deepdisc.git",
     "detectron2@git+https://github.com/facebookresearch/detectron2.git",
     "scarlet@git+https://github.com/pmelchior/scarlet.git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "pz-rail-base",
+    "ceci2 @ https://github.com/LSSTDESC/rail_base",
     "deepdisc@git+https://github.com/lincc-frameworks/deepdisc.git",
     "detectron2@git+https://github.com/facebookresearch/detectron2.git",
     "scarlet@git+https://github.com/pmelchior/scarlet.git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "ceci2 @ https://github.com/LSSTDESC/rail_base",
+    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
     "deepdisc@git+https://github.com/lincc-frameworks/deepdisc.git",
     "detectron2@git+https://github.com/facebookresearch/detectron2.git",
     "scarlet@git+https://github.com/pmelchior/scarlet.git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
+    "pz-rail-base>=1.0.3",
     "deepdisc@git+https://github.com/lincc-frameworks/deepdisc.git",
     "detectron2@git+https://github.com/facebookresearch/detectron2.git",
     "scarlet@git+https://github.com/pmelchior/scarlet.git",

--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -185,7 +185,7 @@ class DeepDiscInformer(CatInformer):
     inputs = [('input', TableHandle), ('metadata', Hdf5Handle)]
 
     def __init__(self, args, **kwargs):
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
 
         # check to make sure that batch_size is an even multiple of num_gpus
         if self.config.batch_size % self.config.num_gpus != 0:
@@ -318,7 +318,7 @@ class DeepDiscPDFEstimator(CatEstimator):
         """Constructor:
         Do Estimator specific initialization"""
         self.nnmodel = None
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
 
     def estimate(self, input_data, input_metadata):
         with tempfile.TemporaryDirectory() as temp_directory_name:
@@ -516,7 +516,7 @@ class DeepDiscPDFEstimatorWithChunking(CatEstimator):
     def __init__(self, args, **kwargs):
         """Constructor:
         Do Estimator specific initialization"""
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
 
         self.nnmodel = None
         self.zgrid = np.linspace(0, 5, 200)

--- a/src/rail/estimation/algos/deepdisc.py
+++ b/src/rail/estimation/algos/deepdisc.py
@@ -184,8 +184,8 @@ class DeepDiscInformer(CatInformer):
     )
     inputs = [('input', TableHandle), ('metadata', Hdf5Handle)]
 
-    def __init__(self, args, comm=None):
-        CatInformer.__init__(self, args, comm=comm)
+    def __init__(self, args, **kwargs):
+        super().__init__(self, args, **kwargs)
 
         # check to make sure that batch_size is an even multiple of num_gpus
         if self.config.batch_size % self.config.num_gpus != 0:
@@ -314,11 +314,11 @@ class DeepDiscPDFEstimator(CatEstimator):
               ("metadata", JsonHandle)]
     outputs = [("output", QPHandle)]
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Constructor:
         Do Estimator specific initialization"""
         self.nnmodel = None
-        CatEstimator.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
 
     def estimate(self, input_data, input_metadata):
         with tempfile.TemporaryDirectory() as temp_directory_name:
@@ -513,10 +513,10 @@ class DeepDiscPDFEstimatorWithChunking(CatEstimator):
               ("metadata", Hdf5Handle)]
     outputs = [("output", QPHandle)]
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Constructor:
         Do Estimator specific initialization"""
-        CatEstimator.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
 
         self.nnmodel = None
         self.zgrid = np.linspace(0, 5, 200)


### PR DESCRIPTION
This PR updates the constructors of all stage subclasses to work with ceci version 2, in which aliases are specified in the constructor. A similar PR has been opened for each RAIL repo.

The main change is to the the constructors to accept any keywords with **kwargs and pass them to the parent class.

I have also removed any constructors which did not do anything except call the parent class constructor. Since this happens automatically if you omit the constructor, these were redundant.

Finally, in constructors I have changed I have removed hard-coded parent classes in favour of the python3 recommended super() function. If the parent class are changed in the future the constructor will still work.