### PR TITLE
Fix unit test error with open-cv import

### DIFF
--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -39,6 +39,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install .
         pip install .[dev]
+	apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Run unit tests with pytest
       run: |

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -36,7 +36,6 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-	sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx
         python -m pip install --upgrade pip
         pip install .
         pip install .[dev]

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-	python -m pip install --upgrade pip
+        python -m pip install --upgrade pip
         pip install .
         pip install .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -40,11 +40,9 @@ jobs:
         pip install .
         pip install .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-
     - name: Install OS dependencies
       run: |
         sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx     
-
     - name: Run unit tests with pytest
       run: |
         python -m pytest tests --cov=deepdisc --cov-report=xml

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -36,11 +36,15 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        python -m pip install --upgrade pip
+	python -m pip install --upgrade pip
         pip install .
         pip install .[dev]
-	apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+    - name: Install OS dependencies
+      run: |
+        sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx     
+
     - name: Run unit tests with pytest
       run: |
         python -m pytest tests --cov=deepdisc --cov-report=xml

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -36,6 +36,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
+	sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx
         python -m pip install --upgrade pip
         pip install .
         pip install .[dev]

--- a/ci-environment.yml
+++ b/ci-environment.yml
@@ -9,7 +9,6 @@ dependencies:
   - ipykernel
   - imgaug
   - numpy
-  - opencv-python
   - pybind11
   - pytorch
   - torchvision
@@ -17,3 +16,4 @@ dependencies:
     - autograd
     - peigen
     - proxmin
+    - opencv-python

--- a/ci-environment.yml
+++ b/ci-environment.yml
@@ -16,4 +16,4 @@ dependencies:
     - autograd
     - peigen
     - proxmin
-    - opencv-python-headless==4.8.1.78
+    - opencv-python-headless

--- a/ci-environment.yml
+++ b/ci-environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - ipykernel
   - imgaug
   - numpy
-  - opencv
+  - opencv-python
   - pybind11
   - pytorch
   - torchvision

--- a/ci-environment.yml
+++ b/ci-environment.yml
@@ -16,4 +16,4 @@ dependencies:
     - autograd
     - peigen
     - proxmin
-    - opencv-python
+    - opencv-python-headless

--- a/ci-environment.yml
+++ b/ci-environment.yml
@@ -16,4 +16,4 @@ dependencies:
     - autograd
     - peigen
     - proxmin
-    - opencv-python-headless
+    - opencv-python-headless==4.8.1.78


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

Unit tests in the CI environment are failing due to an error when importing open-cv

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
